### PR TITLE
Feature/34/support wasm

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -33,6 +33,65 @@ jobs:
           args: ${{ matrix.cargo_args }}
           toolchain: ${{ matrix.rust_toolchain }}
 
+  wasm_tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        build_features:
+          - '"std wasm-bindgen"'
+          - '"std wasm-bindgen jitter"'
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: wasm32-unknown-unknown
+          components: rust-src
+      - uses: browser-actions/setup-geckodriver@latest
+
+      - name: wasm_bindgen Cache
+        id: wasm_bindgen_cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/wasm-bindgen
+            ~/.cargo/bin/wasm-bindgen-test-runner
+          key: ${{ runner.os }}-wasm-bindgen
+
+      - name: 'Install `wasm-pack`'
+        run: cargo install wasm-bindgen-cli --vers "0.2.74"
+        # `wasm-pack` normally handles installing the browser driver and wasm-bindgen-cli which matches the version in
+        # `Cargo.lock`. However, it doesn't yet correctly pass through features to `cargo`.
+        #
+        # See <https://github.com/rustwasm/wasm-pack/issues/698> and <https://github.com/rustwasm/wasm-pack/pull/851>.
+        #
+        # For WASM tests to work, we need to either:
+        #
+        # * Install a custom version of `wasm-pack`, commented out below, or
+        # * Manage the installation of the browser driver, and indicate the WASM bindgen test runner in `.cargo/config`.
+        #
+        # We are currently using the second option.
+
+        # Custom branch
+        #
+        # ```
+        # run: cargo install --git https://github.com/azriel91/wasm-pack.git --branch bugfix/698/build-tests-with-passthrough-args --force
+        # ```
+        #
+        # Ideally we would use:
+        #
+        # ```
+        # uses: jetli/wasm-pack-action@v0.3.0
+        # with:
+        #   version: 'latest'
+        # ```
+
+      - name: 'Run tests'
+        run: cargo test --target wasm32-unknown-unknown --no-default-features --features ${{ matrix.build_features }}
+
   all_tests:
     needs: test
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   request](https://github.com/antifuchs/governor/pull/67) and
   [issue #66](https://github.com/antifuchs/governor/issues/66) for
   details.
+* Support for the `wasm32-unknown-unknown` target. Default features have to be
+  disabled so that native dependencies are not built, and `Jitter` is not
+  available.
 
 ### Changed
 
@@ -25,6 +28,7 @@
 
 ### Contributors
 * [@izik1](https://github.com/izik1)
+* [@azriel91](https://github.com/azriel91)
 
 ## [[0.3.2](https://docs.rs/governor/0.3.2/governor/)] - 2021-01-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,30 @@ keywords = ["rate-limiting", "rate-limit", "no_std", "gcra"]
 # We use criterion, don't infer benchmark files.
 autobenches = false
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+bench = false
+
+[package.metadata.template_ci.bench]
+run = true
+version = "nightly"
+
+[package.metadata.template_ci.clippy]
+run = false
+version = "nightly"
+
+[package.metadata.template_ci.additional_matrix_entries]
+
+[package.metadata.template_ci.additional_matrix_entries.no_std_nightly]
+run = true
+version = "nightly"
+commandline = "cargo +nightly test --no-default-features --features no_std"
+
+[package.metadata.template_ci.additional_matrix_entries.no_std_stable]
+run = true
+version = "stable"
+commandline = "cargo test --no-default-features --features no_std"
+
 [badges]
 maintenance = { status = "actively-developed" }
 
@@ -22,17 +46,16 @@ maintenance = { status = "actively-developed" }
 name = "governor_criterion_benches"
 harness = false
 
-[lib]
-bench = false
-
 [dev-dependencies]
-criterion = {version = "0.3.2", features = ["html_reports"]}
+criterion = { version = "0.3.2", features = ["html_reports"] }
 tynm = "0.1.4"
 crossbeam = "0.8.0"
-libc = "0.2.70"
-futures = "0.3.5"
-proptest = "1.0.0"
+futures = "0.3.15"
 all_asserts = "2.2.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+libc = "0.2.70"
+proptest = "1.0.0"
 
 [features]
 default = ["std", "dashmap", "jitter", "quanta"]
@@ -55,3 +78,7 @@ no-std-compat = { version = "0.4.0", features = [ "alloc", "compat_hash" ] }
 
 # To ensure we don't pull in vulnerable smallvec, see https://github.com/antifuchs/governor/issues/60
 smallvec = "1.6.1"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen-test = "0.3.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ all_asserts = "2.2.0"
 default = ["std", "dashmap", "jitter", "quanta"]
 std = ["no-std-compat/std", "nonzero_ext/std", "futures-timer", "futures"]
 jitter = ["rand"]
+stdweb = ["instant/stdweb"]
+wasm-bindgen = ["futures-timer/wasm-bindgen", "instant/wasm-bindgen"]
 no_std = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ nonzero_ext = { version = "0.2.0", default-features = false }
 parking_lot = "0.11.0"
 futures-timer = { version = "3.0.2", optional = true }
 futures = { version = "0.3.5", optional = true }
+instant = "0.1.7"
 rand = { version = "0.8.0", optional = true }
 dashmap = { version = "4.0.2", optional = true }
 quanta = { version = "0.9.0", optional = true }

--- a/benches/multi_threaded.rs
+++ b/benches/multi_threaded.rs
@@ -8,10 +8,11 @@ use governor::{
     middleware::NoOpMiddleware,
     state::keyed::{DashMapStateStore, HashMapStateStore, KeyedStateStore},
 };
+use instant::Instant;
 use nonzero_ext::*;
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tynm::type_name;
 
 pub fn bench_all(c: &mut Criterion) {

--- a/src/clock/default.rs
+++ b/src/clock/default.rs
@@ -1,5 +1,5 @@
 #[cfg(all(feature = "std", not(feature = "quanta")))]
-/// The default clock that reports [`Instant`][std::time::Instant]s.
+/// The default clock that reports [`Instant`][instant::Instant]s.
 pub type DefaultClock = crate::clock::MonotonicClock;
 
 #[cfg(all(feature = "std", feature = "quanta"))]

--- a/src/clock/with_std.rs
+++ b/src/clock/with_std.rs
@@ -3,8 +3,9 @@ use super::{Clock, Reference};
 use std::prelude::v1::*;
 
 use crate::nanos::Nanos;
+use instant::Instant;
 use std::ops::Add;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
 /// The monotonic clock implemented by [`Instant`].
 #[derive(Clone, Debug, Default)]

--- a/src/gcra.rs
+++ b/src/gcra.rs
@@ -175,6 +175,7 @@ impl From<(&Gcra, Nanos)> for StateSnapshot {
 }
 
 #[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
 mod test {
     use super::*;
     use crate::Quota;

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -11,7 +11,7 @@ use std::ops::Add;
 use std::time::Duration;
 
 #[cfg(feature = "std")]
-use std::time::Instant;
+use instant::Instant;
 
 /// An interval specification for deviating from the nominal wait time.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use errors::*;
 pub use gcra::NotUntil;
 #[cfg(feature = "jitter")]
 pub use jitter::Jitter;
-#[cfg(all(not(feature = "std"), feature = "jitter"))]
+#[cfg(all(not(feature = "jitter"), feature = "std"))]
 pub(crate) use jitter::Jitter;
 pub use quota::Quota;
 #[doc(inline)]

--- a/tests/direct.rs
+++ b/tests/direct.rs
@@ -5,6 +5,14 @@ use governor::{
 use nonzero_ext::nonzero;
 use std::time::Duration;
 
+// Trick so we don't have to annotate each test with:
+// #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
 fn accepts_first_cell() {
     let clock = FakeRelativeClock::default();
@@ -141,6 +149,8 @@ fn correct_wait_time() {
     assert_eq!(20, conforming);
 }
 
+// Crossbeam scoped threads are not supported on WASM
+#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn actual_threadsafety() {
     use crossbeam;

--- a/tests/future.rs
+++ b/tests/future.rs
@@ -1,130 +1,135 @@
 #![cfg(feature = "std")]
 
 use all_asserts::*;
-use futures::executor::block_on;
 use governor::{Quota, RateLimiter};
+use instant::Instant;
 use nonzero_ext::*;
-use std::sync::Arc;
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-#[test]
-fn pauses() {
-    let i = Instant::now();
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+#[cfg(not(target_arch = "wasm32"))]
+use {
+    futures::executor::block_on,
+    std::{sync::Arc, thread},
+};
 
-    // exhaust the limiter:
-    loop {
-        if lim.check().is_err() {
-            break;
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[macro_use]
+mod macros;
+
+tests! {
+    fn pauses() {
+        let i = Instant::now();
+        let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+
+        // exhaust the limiter:
+        loop {
+            if lim.check().is_err() {
+                break;
+            }
         }
+
+        wait!(lim.until_ready());
+        assert_ge!(i.elapsed(), Duration::from_millis(100));
     }
 
-    block_on(lim.until_ready());
-    assert_ge!(i.elapsed(), Duration::from_millis(100));
-}
+    fn pauses_n() {
+        let i = Instant::now();
+        let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
 
-#[test]
-fn pauses_n() {
-    let i = Instant::now();
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
-
-    for _ in 0..6 {
-        lim.check().unwrap();
-    }
-
-    block_on(lim.until_n_ready(nonzero!(5u32))).unwrap();
-    assert_ge!(i.elapsed(), Duration::from_millis(100));
-}
-
-#[test]
-fn pauses_keyed() {
-    let i = Instant::now();
-    let lim = RateLimiter::keyed(Quota::per_second(nonzero!(10u32)));
-
-    // exhaust the limiter:
-    loop {
-        if lim.check_key(&1u32).is_err() {
-            break;
+        for _ in 0..6 {
+            lim.check().unwrap();
         }
+
+        wait!(lim.until_n_ready(nonzero!(5u32))).unwrap();
+        assert_ge!(i.elapsed(), Duration::from_millis(100));
     }
 
-    block_on(lim.until_key_ready(&1u32));
-    assert_ge!(i.elapsed(), Duration::from_millis(100));
-}
+    fn pauses_keyed() {
+        let i = Instant::now();
+        let lim = RateLimiter::keyed(Quota::per_second(nonzero!(10u32)));
 
-#[test]
-fn proceeds() {
-    let i = Instant::now();
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+        // exhaust the limiter:
+        loop {
+            if lim.check_key(&1u32).is_err() {
+                break;
+            }
+        }
 
-    block_on(lim.until_ready());
-    assert_le!(i.elapsed(), Duration::from_millis(100));
-}
-
-#[test]
-fn proceeds_n() {
-    let i = Instant::now();
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
-
-    block_on(lim.until_n_ready(nonzero!(10u32))).unwrap();
-    assert_le!(i.elapsed(), Duration::from_millis(100));
-}
-
-#[test]
-fn proceeds_keyed() {
-    let i = Instant::now();
-    let lim = RateLimiter::keyed(Quota::per_second(nonzero!(10u32)));
-
-    block_on(lim.until_key_ready(&1u32));
-    assert_le!(i.elapsed(), Duration::from_millis(100));
-}
-
-#[test]
-fn multiple() {
-    let i = Instant::now();
-    let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
-    let mut children = vec![];
-
-    for _i in 0..20 {
-        let lim = Arc::clone(&lim);
-        children.push(thread::spawn(move || {
-            block_on(lim.until_ready());
-        }));
+        wait!(lim.until_key_ready(&1u32));
+        assert_ge!(i.elapsed(), Duration::from_millis(100));
     }
-    for child in children {
-        child.join().unwrap();
+
+    fn proceeds() {
+        let i = Instant::now();
+        let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+
+        wait!(lim.until_ready());
+        assert_le!(i.elapsed(), Duration::from_millis(100));
     }
-    // by now we've waited for, on average, 10ms; but sometimes the
-    // test finishes early; let's assume it takes at least 8ms:
-    let elapsed = i.elapsed();
-    assert_ge!(elapsed, Duration::from_millis(8),);
-}
 
-#[test]
-fn multiple_keyed() {
-    let i = Instant::now();
-    let lim = Arc::new(RateLimiter::keyed(Quota::per_second(nonzero!(10u32))));
-    let mut children = vec![];
+    fn proceeds_n() {
+        let i = Instant::now();
+        let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
 
-    for _i in 0..20 {
-        let lim = Arc::clone(&lim);
-        children.push(thread::spawn(move || {
-            block_on(lim.until_key_ready(&1u32));
-        }));
+        wait!(lim.until_n_ready(nonzero!(10u32))).unwrap();
+        assert_le!(i.elapsed(), Duration::from_millis(100));
     }
-    for child in children {
-        child.join().unwrap();
+
+    fn proceeds_keyed() {
+        let i = Instant::now();
+        let lim = RateLimiter::keyed(Quota::per_second(nonzero!(10u32)));
+
+        wait!(lim.until_key_ready(&1u32));
+        assert_le!(i.elapsed(), Duration::from_millis(100));
     }
-    // by now we've waited for, on average, 10ms; but sometimes the
-    // test finishes early; let's assume it takes at least 8ms:
-    let elapsed = i.elapsed();
-    assert_ge!(elapsed, Duration::from_millis(8),);
-}
 
-#[test]
-fn errors_on_exceeded_capacity() {
-    let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+    #[cfg(not(target_arch = "wasm32"))]
+    fn multiple() {
+        let i = Instant::now();
+        let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
+        let mut children = vec![];
 
-    block_on(lim.until_n_ready(nonzero!(11u32))).unwrap_err();
+        for _i in 0..20 {
+            let lim = Arc::clone(&lim);
+            children.push(thread::spawn(move || {
+                wait!(lim.until_ready());
+            }));
+        }
+        for child in children {
+            child.join().unwrap();
+        }
+        // by now we've waited for, on average, 10ms; but sometimes the
+        // test finishes early; let's assume it takes at least 8ms:
+        let elapsed = i.elapsed();
+        assert_ge!(elapsed, Duration::from_millis(8),);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn multiple_keyed() {
+        let i = Instant::now();
+        let lim = Arc::new(RateLimiter::keyed(Quota::per_second(nonzero!(10u32))));
+        let mut children = vec![];
+
+        for _i in 0..20 {
+            let lim = Arc::clone(&lim);
+            children.push(thread::spawn(move || {
+                wait!(lim.until_key_ready(&1u32));
+            }));
+        }
+        for child in children {
+            child.join().unwrap();
+        }
+        // by now we've waited for, on average, 10ms; but sometimes the
+        // test finishes early; let's assume it takes at least 8ms:
+        let elapsed = i.elapsed();
+        assert_ge!(elapsed, Duration::from_millis(8),);
+    }
+
+    fn errors_on_exceeded_capacity() {
+        let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
+
+        wait!(lim.until_n_ready(nonzero!(11u32))).unwrap_err();
+    }
 }

--- a/tests/keyed_dashmap.rs
+++ b/tests/keyed_dashmap.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 #![cfg(all(feature = "std", feature = "dashmap"))]
 
 use governor::{

--- a/tests/keyed_hashmap.rs
+++ b/tests/keyed_hashmap.rs
@@ -7,6 +7,9 @@ use nonzero_ext::nonzero;
 use std::hash::Hash;
 use std::time::Duration;
 
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 const KEYS: &[u32] = &[1u32, 2u32];
 
 #[test]
@@ -96,6 +99,7 @@ fn expiration() {
     assert_eq!(retained_keys(lim_later), Vec::<&str>::new());
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn actual_threadsafety() {
     use crossbeam;

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,0 +1,37 @@
+#[cfg(not(target_arch = "wasm32"))]
+#[macro_export]
+macro_rules! tests {
+    ($($test:item)*) => { $(#[test] $test)* };
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[macro_export]
+macro_rules! wait {
+    ($expr:expr) => {
+        block_on($expr)
+    };
+}
+
+#[cfg(target_arch = "wasm32")]
+#[macro_export]
+macro_rules! tests {
+    ($($(#[$meta:meta])? fn $name:ident() $body:block)*) => {
+        #[cfg(target_arch = "wasm32")]
+        use wasm_bindgen_test::wasm_bindgen_test as test;
+
+        $(
+            #[test]
+            $(#[$meta])?
+            async fn $name()
+            $body
+        )*
+    };
+}
+
+#[cfg(target_arch = "wasm32")]
+#[macro_export]
+macro_rules! wait {
+    ($expr:expr) => {
+        $expr.await
+    };
+}

--- a/tests/memory_leaks.rs
+++ b/tests/memory_leaks.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 #![cfg(feature = "std")]
 
 // This test uses procinfo, so can only be run on Linux.

--- a/tests/proptests.rs
+++ b/tests/proptests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use proptest::prelude::*;
 
 use governor::{

--- a/tests/sinks.rs
+++ b/tests/sinks.rs
@@ -1,66 +1,78 @@
 #![cfg(feature = "std")]
 
 use all_asserts::*;
-use futures::executor::block_on;
 use futures::SinkExt;
-use governor::{prelude::*, Jitter, Quota, RateLimiter};
+use governor::{prelude::*, Quota, RateLimiter};
+use instant::Instant;
 use nonzero_ext::*;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-#[test]
-fn sink() {
-    let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
-    let mut sink = Vec::new().ratelimit_sink(&lim);
-    let i = Instant::now();
+#[cfg(feature = "jitter")]
+use governor::Jitter;
 
-    for _ in 0..10 {
-        block_on(sink.send(())).unwrap();
+#[cfg(not(target_arch = "wasm32"))]
+use futures::executor::block_on;
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[macro_use]
+mod macros;
+
+tests! {
+    fn sink() {
+        let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
+        let mut sink = Vec::new().ratelimit_sink(&lim);
+        let i = Instant::now();
+
+        for _ in 0..10 {
+            wait!(sink.send(())).unwrap();
+        }
+        assert_lt!(i.elapsed(), Duration::from_millis(100));
+
+        wait!(sink.send(())).unwrap();
+        assert_range!((100..=200), i.elapsed().as_millis());
+
+        wait!(sink.send(())).unwrap();
+        assert_range!((200..=300), i.elapsed().as_millis());
+
+        let result = sink.get_ref();
+        assert_eq!(result.len(), 12);
+        assert!(result.into_iter().all(|&elt| elt == ()));
     }
-    assert_lt!(i.elapsed(), Duration::from_millis(100));
 
-    block_on(sink.send(())).unwrap();
-    assert_range!((100..=200), i.elapsed().as_millis());
+    fn auxilliary_sink_methods() {
+        let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
+        // TODO: use futures_ringbuf to build a Sink-that-is-a-Stream and
+        // use it as both
+        // (https://github.com/najamelan/futures_ringbuf/issues/5)
+        let mut sink = Vec::<u8>::new().ratelimit_sink(&lim);
 
-    block_on(sink.send(())).unwrap();
-    assert_range!((200..=300), i.elapsed().as_millis());
-
-    let result = sink.get_ref();
-    assert_eq!(result.len(), 12);
-    assert!(result.into_iter().all(|&elt| elt == ()));
-}
-
-#[test]
-fn auxilliary_sink_methods() {
-    let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
-    // TODO: use futures_ringbuf to build a Sink-that-is-a-Stream and
-    // use it as both
-    // (https://github.com/najamelan/futures_ringbuf/issues/5)
-    let mut sink = Vec::<u8>::new().ratelimit_sink(&lim);
-
-    // Closes the underlying sink:
-    assert!(block_on(sink.close()).is_ok());
-}
-
-#[cfg_attr(feature = "jitter", test)]
-fn sink_with_jitter() {
-    let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
-    let mut sink =
-        Vec::new().ratelimit_sink_with_jitter(&lim, Jitter::up_to(Duration::from_nanos(1)));
-    let i = Instant::now();
-
-    for _ in 0..10 {
-        block_on(sink.send(())).unwrap();
+        // Closes the underlying sink:
+        assert!(wait!(sink.close()).is_ok());
     }
-    assert_le!(i.elapsed(), Duration::from_millis(100),);
 
-    block_on(sink.send(())).unwrap();
-    assert_range!((100..=200), i.elapsed().as_millis());
+    #[cfg(feature = "jitter")]
+    fn sink_with_jitter() {
+        let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
+        let mut sink =
+            Vec::new().ratelimit_sink_with_jitter(&lim, Jitter::up_to(Duration::from_nanos(1)));
+        let i = Instant::now();
 
-    block_on(sink.send(())).unwrap();
-    assert_range!((200..=300), i.elapsed().as_millis());
+        for _ in 0..10 {
+            wait!(sink.send(())).unwrap();
+        }
+        assert_le!(i.elapsed(), Duration::from_millis(100),);
 
-    let result = sink.into_inner();
-    assert_eq!(result.len(), 12);
-    assert!(result.into_iter().all(|elt| elt == ()));
+        wait!(sink.send(())).unwrap();
+        assert_range!((100..=200), i.elapsed().as_millis());
+
+        wait!(sink.send(())).unwrap();
+        assert_range!((200..=300), i.elapsed().as_millis());
+
+        let result = sink.into_inner();
+        assert_eq!(result.len(), 12);
+        assert!(result.into_iter().all(|elt| elt == ()));
+    }
 }

--- a/tests/streams.rs
+++ b/tests/streams.rs
@@ -1,28 +1,38 @@
 #![cfg(feature = "std")]
 
-use futures::executor::block_on;
 use futures::{stream, StreamExt};
 use governor::{prelude::*, Quota, RateLimiter};
+use instant::Instant;
 use nonzero_ext::*;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-#[test]
-fn stream() {
-    let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
-    let mut stream = stream::repeat(()).ratelimit_stream(&lim);
-    let i = Instant::now();
+#[cfg(not(target_arch = "wasm32"))]
+use futures::executor::block_on;
 
-    for _ in 0..10 {
-        block_on(stream.next());
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[macro_use]
+mod macros;
+
+tests! {
+    fn stream() {
+        let lim = Arc::new(RateLimiter::direct(Quota::per_second(nonzero!(10u32))));
+        let mut stream = stream::repeat(()).ratelimit_stream(&lim);
+        let i = Instant::now();
+
+        for _ in 0..10 {
+            wait!(stream.next());
+        }
+        assert!(i.elapsed() <= Duration::from_millis(100));
+
+        wait!(stream.next());
+        assert!(i.elapsed() >= Duration::from_millis(100));
+        assert!(i.elapsed() <= Duration::from_millis(200));
+
+        wait!(stream.next());
+        assert!(i.elapsed() >= Duration::from_millis(200));
+        assert!(i.elapsed() <= Duration::from_millis(300));
     }
-    assert!(i.elapsed() <= Duration::from_millis(100));
-
-    block_on(stream.next());
-    assert!(i.elapsed() > Duration::from_millis(100));
-    assert!(i.elapsed() <= Duration::from_millis(200));
-
-    block_on(stream.next());
-    assert!(i.elapsed() > Duration::from_millis(200));
-    assert!(i.elapsed() <= Duration::from_millis(300));
 }

--- a/tests/streams.rs
+++ b/tests/streams.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "std")]
 
+use all_asserts::*;
 use futures::{stream, StreamExt};
 use governor::{prelude::*, Quota, RateLimiter};
 use instant::Instant;
@@ -28,11 +29,9 @@ tests! {
         assert!(i.elapsed() <= Duration::from_millis(100));
 
         wait!(stream.next());
-        assert!(i.elapsed() >= Duration::from_millis(100));
-        assert!(i.elapsed() <= Duration::from_millis(200));
+        assert_range!((100..=200), i.elapsed().as_millis());
 
         wait!(stream.next());
-        assert!(i.elapsed() >= Duration::from_millis(200));
-        assert!(i.elapsed() <= Duration::from_millis(300));
+        assert_range!((200..=300), i.elapsed().as_millis());
     }
 }


### PR DESCRIPTION
(this is based over #33)

Closes #34.

Attempt to support WASM. This builds and runs in a WASM application, but requires the following PRs:

* [x] https://github.com/sebcrozet/instant/pull/17 -- provide `Instant::checked_sub`. Needs `instant` release > `0.1.3` (https://github.com/sebcrozet/instant/issues/18)
* [x] https://github.com/Amanieu/parking_lot/pull/231 -- use `instant::Instant`. Needs [`parking_lot`](https://github.com/Amanieu/parking_lot) release > `0.10.2`.
