### PR TITLE
Add a contains_key method

### DIFF
--- a/governor/CHANGELOG.md
+++ b/governor/CHANGELOG.md
@@ -9,6 +9,10 @@
   `DefaultKeyedRateLimiter` to cut down on type-typing of typical rate
   limiters in struct and function definitions. Requested in
   [#85](https://github.com/antifuchs/governor/issues/85).
+* New method `contains_key` that can be used to check if a
+  `RateLimiter` has a given key (which can be used to prevent
+  arbitrary attacker-controlled memory usage in case of a DDoS
+  attack).
 
 ### Changed
 * The API for `.check_n` and `.until_n` (and their keyed counterpart)

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -46,6 +46,8 @@ pub trait StateStore {
     fn measure_and_replace<T, F, E>(&self, key: &Self::Key, f: F) -> Result<T, E>
     where
         F: Fn(Option<Nanos>) -> Result<(T, Nanos), E>;
+
+    fn contains_key(&self, key: &Self::Key) -> bool;
 }
 
 /// A rate limiter.

--- a/governor/src/state/direct.rs
+++ b/governor/src/state/direct.rs
@@ -135,4 +135,10 @@ mod test {
     fn not_keyed_impls_coverage() {
         assert_eq!(NotKeyed::NonKey, NotKeyed::NonKey);
     }
+
+    #[test]
+    fn not_keyed_contains_key_impls_coverage() {
+        let state = InMemoryState::default();
+        assert!(state.contains_key(&NotKeyed::NonKey));
+    }
 }

--- a/governor/src/state/in_memory.rs
+++ b/governor/src/state/in_memory.rs
@@ -59,6 +59,10 @@ impl StateStore for InMemoryState {
     {
         self.measure_and_replace_one(f)
     }
+
+    fn contains_key(&self, _key: &Self::Key) -> bool {
+        true
+    }
 }
 
 impl Debug for InMemoryState {

--- a/governor/src/state/keyed/dashmap.rs
+++ b/governor/src/state/keyed/dashmap.rs
@@ -27,6 +27,10 @@ impl<K: Hash + Eq + Clone> StateStore for DashMapStateStore<K> {
         let entry = self.entry(key.clone()).or_default();
         (*entry).measure_and_replace_one(f)
     }
+
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        self.contains_key(key)
+    }
 }
 
 /// # Keyed rate limiters - [`DashMap`]-backed

--- a/governor/src/state/keyed/hashmap.rs
+++ b/governor/src/state/keyed/hashmap.rs
@@ -37,6 +37,11 @@ impl<K: Hash + Eq + Clone> StateStore for HashMapStateStore<K> {
             .or_insert_with(InMemoryState::default);
         entry.measure_and_replace_one(f)
     }
+
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        let map = self.lock();
+        (*map).contains_key(key)
+    }
 }
 
 impl<K: Hash + Eq + Clone> ShrinkableKeyedStateStore<K> for HashMapStateStore<K> {

--- a/governor/tests/keyed_dashmap.rs
+++ b/governor/tests/keyed_dashmap.rs
@@ -16,7 +16,9 @@ fn accepts_first_cell() {
     let clock = FakeRelativeClock::default();
     let lb = RateLimiter::dashmap_with_clock(Quota::per_second(nonzero!(5u32)), &clock);
     for key in KEYS {
+        assert!(!lb.contains_key(&key));
         assert_eq!(Ok(()), lb.check_key(&key), "key {:?}", key);
+        assert!(lb.contains_key(&key));
     }
 }
 

--- a/governor/tests/keyed_hashmap.rs
+++ b/governor/tests/keyed_hashmap.rs
@@ -14,7 +14,9 @@ fn accepts_first_cell() {
     let clock = FakeRelativeClock::default();
     let lb = RateLimiter::hashmap_with_clock(Quota::per_second(nonzero!(5u32)), &clock);
     for key in KEYS {
+        assert!(!lb.contains_key(&key));
         assert_eq!(Ok(()), lb.check_key(&key), "key {:?}", key);
+        assert!(lb.contains_key(&key));
     }
 }
 


### PR DESCRIPTION
This should fix #171 - currently, we have no good way of letting people control the memory usage of keyed rate limiter states. This at least allows them to tell whether a test would add a new key (consuming memory) - and then rate-limit that.