### PR TITLE
Fix duplicate link in doc reference

### DIFF
--- a/governor/src/_guide.rs
+++ b/governor/src/_guide.rs
@@ -92,7 +92,7 @@
 //! function arguments. The [`crate::RateLimiter`] type signatures
 //! tend to be pretty unwieldy for that, so this crate exports a pair
 //! of handy type aliases, [`crate::DefaultDirectRateLimiter`] and
-//! [`crate::DefaultDirectRateLimiter`].
+//! [`crate::DefaultKeyedRateLimiter`].
 //!
 //! Here's an example for embedding a direct rate limiter in a struct:
 //!


### PR DESCRIPTION
In the guide, there is a duplicate reference for the `DefaultDirectRateLimiter` under the heading [Type signatures for rate limiters](https://docs.rs/governor/latest/governor/_guide/index.html#type-signatures-for-rate-limiters). This fixes the second so it points to the keyed rate limiter instead, since I presume that's what it was supposed to be.