### PR TITLE
no_std: spinning_top, portable-atomic

### DIFF
--- a/governor/Cargo.toml
+++ b/governor/Cargo.toml
@@ -37,13 +37,15 @@ all_asserts = "2.2.0"
 [features]
 default = ["std", "dashmap", "jitter", "quanta"]
 quanta = ["dep:quanta"]
-std = ["no-std-compat/std", "nonzero_ext/std", "futures-timer", "futures"]
+std = ["no-std-compat/std", "nonzero_ext/std", "futures-timer", "futures", "dep:parking_lot"]
 jitter = ["rand"]
 no_std = ["no-std-compat/compat_hash"]
 
 [dependencies]
 nonzero_ext = { version = "0.3.0", default-features = false }
-parking_lot = "0.12.0"
+parking_lot = { version = "0.12", optional = true }
+spinning_top = "0.3"
+portable-atomic = { version = "1.6", features = ["require-cas"] }
 futures-timer = { version = "3.0.2", optional = true }
 futures = { version = "0.3.5", optional = true }
 rand = { version = "0.8.0", optional = true }

--- a/governor/src/clock.rs
+++ b/governor/src/clock.rs
@@ -50,10 +50,11 @@ use std::prelude::v1::*;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::ops::Add;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+
+use portable_atomic::AtomicU64;
 
 use crate::nanos::Nanos;
 

--- a/governor/src/state/in_memory.rs
+++ b/governor/src/state/in_memory.rs
@@ -5,9 +5,10 @@ use crate::state::{NotKeyed, StateStore};
 use std::fmt;
 use std::fmt::Debug;
 use std::num::NonZeroU64;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+
+use portable_atomic::AtomicU64;
 
 /// An in-memory representation of a GCRA's rate-limiting state.
 ///

--- a/governor/src/state/keyed/hashmap.rs
+++ b/governor/src/state/keyed/hashmap.rs
@@ -10,7 +10,12 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 use crate::state::keyed::ShrinkableKeyedStateStore;
-use parking_lot::Mutex;
+
+#[cfg(feature = "std")]
+type Mutex<T> = parking_lot::Mutex<T>;
+
+#[cfg(not(feature = "std"))]
+type Mutex<T> = spinning_top::Spinlock<T>;
 
 /// A thread-safe (but not very performant) implementation of a keyed rate limiter state
 /// store using [`HashMap`].
@@ -66,7 +71,7 @@ where
 {
     /// Constructs a new rate limiter with a custom clock, backed by a [`HashMap`].
     pub fn hashmap_with_clock(quota: Quota, clock: &C) -> Self {
-        let state: HashMapStateStore<K> = Mutex::new(HashMap::new());
+        let state: HashMapStateStore<K> = HashMapStateStore::new(HashMap::new());
         RateLimiter::new(quota, state, clock)
     }
 }


### PR DESCRIPTION
Fix `#![no_std]` support.

- Stop using `parking_lot` in `no_std` -- it never worked -- and switch to `spinning_top` instead. Ideally this would make use of `lock_api` directly, but I don't have time to chase the type signature changes through the tests at the moment.
- Switch atomic usage to `portable_atomic`.

I'd also recommend adding a `cargo check --target thumbv7em-none-eabi` (or similar `no_std` target) to the CI pipeline in the future, as the tests don't cover `no_std` for dependencies (see below).

## notes

#29 (which introduced this change) looks like it was generated by shotgunning dependency analysis tools without reading or understanding the implications (notably, it was during GitHub's Hacktoberfest event, which is notorious for this).

`parking_lot` does not work, and to my knowledge never has worked, in `no_std` environments:

- No `#![no_std]` declaration in `parking_lot` https://github.com/Amanieu/parking_lot/blob/master/src/lib.rs#L11-L14
- No `#![no_std]` declaration in `parking_lot_core` https://github.com/Amanieu/parking_lot/blob/master/core/src/lib.rs#L39-L54
- The [rustsec advisory](https://rustsec.org/advisories/RUSTSEC-2019-0031) linked in #29 does not advise replacement of `spin` with `parking_lot`, but with `lock_api` (a part of the `parking_lot` project):

> Consider the following alternatives (all of which support no_std):
> ...
>- [lock_api](https://crates.io/crates/lock_api) (a subproject of parking_lot)
>   - [spinning_top](https://github.com/rust-osdev/spinning_top) spinlock crate built on lock_api
>
> ...

## ci / testing

I notice that someone reported this issue in #96 and it was closed because CI is passing. However, rust's `libtest` transitively includes `libstd`, i.e. `cargo test` can't be run without including `std`. `governor` may be built for test without `std`, but its dependencies are not.

```console
governor/ $ rustup target add thumbv7em-none-eabi
governor/ $ cargo check --target thumbv7em-none-eabi --no-default-features --features no_std
error[E0463]: can't find crate for `std`
  |
  = note: the `thumbv7em-none-eabi` target may not support the standard library
  = note: `std` is required by `parking_lot_core` because it does not declare `#![no_std]`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`
```

