### PR TITLE
Fix Reversed Logic for QuantaUpkeepInstant.now()

### DIFF
--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -100,7 +100,9 @@ impl Clock for QuantaUpkeepClock {
 
     fn now(&self) -> Self::Instant {
         QuantaInstant(Nanos::from(
-            self.clock.recent().saturating_duration_since(self.reference),
+            self.clock
+                .recent()
+                .saturating_duration_since(self.reference),
         ))
     }
 }

--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -135,11 +135,11 @@ mod test {
     }
 
     #[test]
-    fn quanta_upkeep_impls_coverage() {
+    fn quanta_upkeep_impls_coverage_and_advances() {
         let one_ns = Nanos::new(1);
         // let _c1 =
         //     QuantaUpkeepClock::from_builder(quanta::Upkeep::new(Duration::from_secs(1))).unwrap();
-        let c = QuantaUpkeepClock::from_interval(Duration::from_secs(1)).unwrap();
+        let c = QuantaUpkeepClock::from_interval(Duration::from_micros(10)).unwrap();
         let now = c.now();
         assert_ne!(now + one_ns, now);
         assert_eq!(one_ns, Reference::duration_since(&(now + one_ns), now));
@@ -148,15 +148,13 @@ mod test {
             Reference::saturating_sub(&(now + Duration::from_nanos(1).into()), one_ns),
             now
         );
-    }
 
-    #[test]
-    fn quanta_upkeep_advances() {
-        let clock = QuantaUpkeepClock::from_interval(Duration::from_micros(10)).unwrap();
-        let start = clock.now();
+        // Test clock advances over time.
+        // (included in one test as only one QuantaUpkeepClock thread can be run at a time)
+        let start = c.now();
         for _ in 0..10 {
             thread::sleep(Duration::from_micros(100));
-            let now = clock.now();
+            let now = c.now();
             assert!(now > start, "now={:?} not after start={:?}", now, start);
         }
     }

--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -155,7 +155,13 @@ mod test {
         for i in 0..5 {
             thread::sleep(Duration::from_millis(250));
             let now = c.now();
-            assert!(now > start, "now={:?} not after start={:?} on iteration={}", now, start, i);
+            assert!(
+                now > start,
+                "now={:?} not after start={:?} on iteration={}",
+                now,
+                start,
+                i
+            );
         }
     }
 }

--- a/governor/src/clock/quanta.rs
+++ b/governor/src/clock/quanta.rs
@@ -139,7 +139,7 @@ mod test {
         let one_ns = Nanos::new(1);
         // let _c1 =
         //     QuantaUpkeepClock::from_builder(quanta::Upkeep::new(Duration::from_secs(1))).unwrap();
-        let c = QuantaUpkeepClock::from_interval(Duration::from_micros(10)).unwrap();
+        let c = QuantaUpkeepClock::from_interval(Duration::from_millis(50)).unwrap();
         let now = c.now();
         assert_ne!(now + one_ns, now);
         assert_eq!(one_ns, Reference::duration_since(&(now + one_ns), now));
@@ -152,10 +152,10 @@ mod test {
         // Test clock advances over time.
         // (included in one test as only one QuantaUpkeepClock thread can be run at a time)
         let start = c.now();
-        for _ in 0..10 {
-            thread::sleep(Duration::from_micros(100));
+        for i in 0..5 {
+            thread::sleep(Duration::from_millis(250));
             let now = c.now();
-            assert!(now > start, "now={:?} not after start={:?}", now, start);
+            assert!(now > start, "now={:?} not after start={:?} on iteration={}", now, start, i);
         }
     }
 }


### PR DESCRIPTION
Logic for comparing `self.reference` and `self.clock.recent()` was reversed resulting in `now()` always returning `Nanos(0)`.