### PR TITLE
All clippy warnings that currently block compliation

### DIFF
--- a/governor/src/clock/with_std.rs
+++ b/governor/src/clock/with_std.rs
@@ -111,6 +111,7 @@ mod test {
             #[test]
             fn instant_impls_coverage() {
                 let one_ns = Nanos::new(1);
+                #[allow(clippy::default_constructed_unit_structs)]
                 let c = MonotonicClock::default();
                 let now = c.now();
                 let ns_dur = Duration::from(one_ns);
@@ -128,6 +129,7 @@ mod test {
     #[test]
     fn system_clock_impls_coverage() {
         let one_ns = Nanos::new(1);
+        #[allow(clippy::default_constructed_unit_structs)]
         let c = SystemClock::default();
         let now = c.now();
         assert_ne!(now + one_ns, now);

--- a/governor/src/errors.rs
+++ b/governor/src/errors.rs
@@ -29,9 +29,15 @@ mod test {
     #[test]
     fn coverage() {
         let display_output = format!("{}", InsufficientCapacity(3));
-        assert!(display_output.contains("3"));
+        #[allow(clippy::single_char_pattern)]
+        {
+            assert!(display_output.contains("3"));
+        }
         let debug_output = format!("{:?}", InsufficientCapacity(3));
-        assert!(debug_output.contains("3"));
+        #[allow(clippy::single_char_pattern)]
+        {
+            assert!(debug_output.contains("3"));
+        }
         assert_eq!(InsufficientCapacity(3), InsufficientCapacity(3));
     }
 }

--- a/governor/src/jitter.rs
+++ b/governor/src/jitter.rs
@@ -202,7 +202,10 @@ mod test {
         let low = Duration::from_secs(0);
         let high = Duration::from_secs(20);
         let sampler = UniformJitter::new_inclusive(Nanos::from(low), Nanos::from(high));
-        assert!(format!("{:?}", sampler).len() > 0);
-        assert!(format!("{:?}", sampler.clone()).len() > 0);
+        #[allow(clippy::len_zero)]
+        {
+            assert!(format!("{:?}", sampler).len() > 0);
+            assert!(format!("{:?}", sampler.clone()).len() > 0);
+        }
     }
 }

--- a/governor/src/state/direct/future.rs
+++ b/governor/src/state/direct/future.rs
@@ -106,7 +106,10 @@ mod test {
     #[test]
     fn insufficient_capacity_impl_coverage() {
         let i = InsufficientCapacity(1);
-        assert_eq!(i.0, i.clone().0);
+        #[allow(clippy::clone_on_copy)]
+        {
+            assert_eq!(i.0, i.clone().0);
+        }
         assert_gt!(format!("{}", i).len(), 0);
     }
 }

--- a/governor/src/state/direct/streams.rs
+++ b/governor/src/state/direct/streams.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::duplicated_attributes)]
 #![cfg(feature = "std")]
 
 use std::prelude::v1::*;


### PR DESCRIPTION
Versions:
rustc 1.79.0 
clippy 0.1.79

Warnings:
clippy::default_constructed_unit_structs
clippy::single_char_pattern
clippy::len_zero
clippy::clone_on_copy
clippy::duplicated_attributes

After going back through to check for these I realised all of them except `clippy::duplicated_attributes` occur in tests and therefore can likely be ignored.

Changing 
```rust
#![deny(warnings)]
```
to
```rust
#![cfg_attr(not(test), deny(warnings))]
```
should allow the crate to compile (barring  `clippy::duplicated_attributes`). 

As a suggestion I would read over [this](https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html) and consider if you even want to keep `deny(warnings)` in general.