### PR TITLE
chore(deps): replace futures with futures-util & futures-executor

### DIFF
--- a/governor/Cargo.toml
+++ b/governor/Cargo.toml
@@ -33,14 +33,14 @@ criterion = {version = "0.5.1", features = ["html_reports"]}
 tynm = "0.1.4"
 crossbeam = "0.8.0"
 libc = "0.2.70"
-futures = "0.3.5"
+futures-executor = "0.3.31"
 proptest = "1.0.0"
 all_asserts = "2.2.0"
 
 [features]
 default = ["std", "dashmap", "jitter", "quanta"]
 quanta = ["dep:quanta"]
-std = ["no-std-compat/std", "nonzero_ext/std", "futures-timer", "futures", "dep:parking_lot"]
+std = ["no-std-compat/std", "nonzero_ext/std", "dep:futures-timer", "dep:futures-util", "dep:futures-sink", "dep:parking_lot"]
 jitter = ["rand"]
 no_std = ["no-std-compat/compat_hash"]
 
@@ -49,8 +49,9 @@ nonzero_ext = { version = "0.3.0", default-features = false }
 parking_lot = { version = "0.12", optional = true }
 spinning_top = "0.3"
 portable-atomic = { version = "1.6", features = ["require-cas"] }
-futures-timer = { version = "3.0.2", optional = true }
-futures = { version = "0.3.5", optional = true }
+futures-timer = { version = "3.0.3", optional = true }
+futures-util = { version = "0.3.31", optional = true, default-features = false, features = ["std", "sink"] }
+futures-sink = { version = "0.3.31", optional = true }
 rand = { version = "0.8.0", optional = true }
 dashmap = { version = "5.1.0", optional = true }
 quanta = { version = "0.12.0", optional = true }

--- a/governor/src/state/direct/sinks.rs
+++ b/governor/src/state/direct/sinks.rs
@@ -6,13 +6,13 @@ use crate::{
     state::{DirectStateStore, NotKeyed},
     Jitter, NotUntil, RateLimiter,
 };
-use futures::task::{Context, Poll};
-use futures::{Future, Sink, Stream};
 use futures_timer::Delay;
+use futures_util::task::{Context, Poll};
+use futures_util::{Future, Sink, Stream};
 use std::marker::PhantomData;
 use std::pin::Pin;
 
-/// Allows converting a [`futures::Sink`] combinator into a rate-limited sink.
+/// Allows converting a [`futures_util::Sink`] combinator into a rate-limited sink.
 pub trait SinkRateLimitExt<Item, S>: Sink<Item>
 where
     S: Sink<Item>,
@@ -84,7 +84,7 @@ enum State {
     Ready,
 }
 
-/// A [`Sink`][futures::Sink] combinator that only allows sending elements when the rate-limiter
+/// A [`Sink`][futures_util::Sink] combinator that only allows sending elements when the rate-limiter
 /// allows it.
 pub struct RatelimitedSink<
     'a,
@@ -131,15 +131,15 @@ impl<
     /// Acquires a mutable reference to the underlying sink that this combinator is sending into.
     ///
     /// ```
-    /// # futures::executor::block_on(async {
-    /// # use futures::sink::{self, SinkExt};
+    /// # futures_executor::block_on(async {
+    /// # use futures_util::sink::{self, SinkExt};
     /// # use nonzero_ext::nonzero;
     /// use governor::{prelude::*, RateLimiter, Quota};
     /// let drain = sink::drain();
     /// let lim = RateLimiter::direct(Quota::per_second(nonzero!(10u32)));
     /// let mut limited = drain.ratelimit_sink(&lim);
     /// limited.get_mut().send(5).await?;
-    /// # Ok::<(), futures::never::Never>(()) }).unwrap();
+    /// # Ok::<(), futures_util::never::Never>(()) }).unwrap();
     /// ```
     pub fn get_mut(&mut self) -> &mut S {
         &mut self.inner
@@ -228,7 +228,7 @@ where
     }
 }
 
-/// Pass-through implementation for [`futures::Stream`] if the Sink also implements it.
+/// Pass-through implementation for [`futures_util::Stream`] if the Sink also implements it.
 impl<
         'a,
         Item,

--- a/governor/src/state/direct/streams.rs
+++ b/governor/src/state/direct/streams.rs
@@ -7,13 +7,13 @@ use crate::{
     middleware::RateLimitingMiddleware,
     state::{DirectStateStore, NotKeyed},
 };
-use futures::task::{Context, Poll};
-use futures::{Future, Sink, Stream};
 use futures_timer::Delay;
+use futures_util::task::{Context, Poll};
+use futures_util::{Future, Sink, Stream};
 use std::pin::Pin;
 use std::time::Duration;
 
-/// Allows converting a [`futures::Stream`] combinator into a rate-limited stream.
+/// Allows converting a [`futures_util::Stream`] combinator into a rate-limited stream.
 pub trait StreamRateLimitExt<'a>: Stream {
     /// Limits the rate at which the stream produces items.
     ///
@@ -97,7 +97,7 @@ enum State {
     Wait,
 }
 
-/// A [`Stream`][futures::Stream] combinator which will limit the rate of items being received.
+/// A [`Stream`][futures_util::Stream] combinator which will limit the rate of items being received.
 ///
 /// This is produced by the [`StreamRateLimitExt::ratelimit_stream`] and
 /// [`StreamRateLimitExt::ratelimit_stream_with_jitter`] methods.
@@ -127,7 +127,7 @@ impl<
 {
     /// Acquires a reference to the underlying stream that this combinator is pulling from.
     /// ```rust
-    /// # use futures::{Stream, stream};
+    /// # use futures_util::{Stream, stream};
     /// # use governor::{prelude::*, Quota, RateLimiter};
     /// # use nonzero_ext::nonzero;
     /// let inner = stream::repeat(());
@@ -142,8 +142,8 @@ impl<
 
     /// Acquires a mutable reference to the underlying stream that this combinator is pulling from.
     /// ```rust
-    /// # use futures::{stream, StreamExt};
-    /// # use futures::executor::block_on;
+    /// # use futures_util::{stream, StreamExt};
+    /// # use futures_executor::block_on;
     /// # use governor::{prelude::*, Quota, RateLimiter};
     /// # use nonzero_ext::nonzero;
     /// let inner = stream::repeat(());
@@ -159,8 +159,8 @@ impl<
     /// which it has already produced but which is still being held back
     /// in order to abide by the limiter.
     /// ```rust
-    /// # use futures::{stream, StreamExt};
-    /// # use futures::executor::block_on;
+    /// # use futures_util::{stream, StreamExt};
+    /// # use futures_executor::block_on;
     /// # use governor::{prelude::*, Quota, RateLimiter};
     /// # use nonzero_ext::nonzero;
     /// let inner = stream::repeat(());
@@ -174,7 +174,7 @@ impl<
     }
 }
 
-/// Implements the [`futures::Stream`] combinator.
+/// Implements the [`futures_util::Stream`] combinator.
 impl<'a, S: Stream, D: DirectStateStore, C: clock::Clock, MW> Stream
     for RatelimitedStream<'a, S, D, C, MW>
 where
@@ -241,7 +241,7 @@ where
     }
 }
 
-/// Pass-through implementation for [`futures::Sink`] if the Stream also implements it.
+/// Pass-through implementation for [`futures_util::Sink`] if the Stream also implements it.
 impl<
         'a,
         Item,

--- a/governor/tests/future.rs
+++ b/governor/tests/future.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "std")]
 
 use all_asserts::*;
-use futures::executor::block_on;
+use futures_executor::block_on;
 use governor::{Quota, RateLimiter};
 use nonzero_ext::*;
 use std::sync::Arc;

--- a/governor/tests/sinks.rs
+++ b/governor/tests/sinks.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "std")]
 
 use all_asserts::*;
-use futures::executor::block_on;
-use futures::SinkExt;
+use futures_executor::block_on;
+use futures_util::sink::SinkExt;
 use governor::{prelude::*, Quota, RateLimiter};
 use nonzero_ext::*;
 use std::sync::Arc;

--- a/governor/tests/streams.rs
+++ b/governor/tests/streams.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "std")]
 
-use futures::executor::block_on;
-use futures::{stream, StreamExt};
+use futures_executor::block_on;
+use futures_util::{stream, StreamExt};
 use governor::{prelude::*, Quota, RateLimiter};
 use nonzero_ext::*;
 use std::sync::Arc;


### PR DESCRIPTION
As the title says, this replaces the direct dependency on the entire `features` crate in favor of a smaller `futures-util`. This change removes 4 dependencies from the dependency tree.