### PR TITLE
release_pr.yml: Pass "governor" crate name explicitly

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -32,7 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ inputs.version }}
           check-semver: true
-          crate-release-all: true # all in workspace
+          crate-name: "governor"
       - uses: actions-ecosystem/action-regex-match@v2
         id: pr-id
         with:


### PR DESCRIPTION
The release-pr action apparently can't deal with workspaces that contain only one crate, so let's pass "governor" in explicitly.