### PR TITLE
Differentiate between GCRA burst capacity and tolerance

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ allow = [
     "BSD-3-Clause",
     "BSD-2-Clause",
     "MIT",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
 ]
 deny = []

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -150,9 +150,9 @@ impl Gcra {
         let t = self.t;
         let additional_weight = t * (n.get() - 1) as u64;
 
-        // check that we can allow enough cells through. Note that `additional_weight` is the
-        // value of the cells *in addition* to the first cell - so add that first cell back.
-        if additional_weight + t > tau {
+        // Check that we can allow enough cells through. Note that both `additional_weight` and
+        // `tau` represent the value of the cells *in addition* to the first cell.
+        if additional_weight > tau {
             return Err(InsufficientCapacity(
                 1 + (self.tau.as_u64() / t.as_u64()) as u32,
             ));

--- a/governor/src/middleware.rs
+++ b/governor/src/middleware.rs
@@ -74,7 +74,9 @@ pub struct StateSnapshot {
     /// The "weight" of a single packet in units of time.
     t: Nanos,
 
-    /// The "burst capacity" of the bucket.
+    /// The "tolerance" of the bucket.
+    ///
+    /// The total "burst capacity" of the bucket is `t + tau`.
     tau: Nanos,
 
     /// The time at which the measurement was taken.
@@ -106,10 +108,10 @@ impl StateSnapshot {
     /// If this state snapshot is based on a negative rate limiting
     /// outcome, this method returns 0.
     pub fn remaining_burst_capacity(&self) -> u32 {
-        let t0 = self.time_of_measurement + self.t;
+        let t0 = self.time_of_measurement;
         (cmp::min(
-            (t0 + self.tau).saturating_sub(self.tat).as_u64(),
-            self.tau.as_u64(),
+            (t0 + self.tau + self.t).saturating_sub(self.tat).as_u64(),
+            (self.tau + self.t).as_u64(),
         ) / self.t.as_u64()) as u32
     }
 }

--- a/governor/src/quota.rs
+++ b/governor/src/quota.rs
@@ -190,14 +190,14 @@ impl Quota {
     /// This is useful mainly for [`crate::middleware::RateLimitingMiddleware`]
     /// where custom code may want to construct information based on
     /// the amount of burst balance remaining.
-    pub(crate) fn from_gcra_parameters(t: Nanos, capacity: Nanos) -> Quota {
+    pub(crate) fn from_gcra_parameters(t: Nanos, tau: Nanos) -> Quota {
         // Safety assurance: by construction, the computed value is bounded by
         // one at the lower.
         //
         // The casts may look a little sketch, but they're constructed from
         // parameters that came from the crate exactly like that.
         let max_burst =
-            unsafe { NonZeroU32::new_unchecked(1 + (capacity.as_u64() / t.as_u64()) as u32) };
+            unsafe { NonZeroU32::new_unchecked(1 + (tau.as_u64() / t.as_u64()) as u32) };
         let replenish_1_per = t.into();
         Quota {
             max_burst,

--- a/governor/src/quota.rs
+++ b/governor/src/quota.rs
@@ -190,15 +190,14 @@ impl Quota {
     /// This is useful mainly for [`crate::middleware::RateLimitingMiddleware`]
     /// where custom code may want to construct information based on
     /// the amount of burst balance remaining.
-    pub(crate) fn from_gcra_parameters(t: Nanos, tau: Nanos) -> Quota {
-        // Safety assurance: As we're calling this from this crate
-        // only, and we do not allow creating a Gcra from 0
-        // parameters, this is, in fact, safe.
+    pub(crate) fn from_gcra_parameters(t: Nanos, capacity: Nanos) -> Quota {
+        // Safety assurance: by construction, the computed value is bounded by
+        // one at the lower.
         //
-        // The casts may look a little sketch, but again, they're
-        // constructed from parameters that came from the crate
-        // exactly like that.
-        let max_burst = unsafe { NonZeroU32::new_unchecked((tau.as_u64() / t.as_u64()) as u32) };
+        // The casts may look a little sketch, but they're constructed from
+        // parameters that came from the crate exactly like that.
+        let max_burst =
+            unsafe { NonZeroU32::new_unchecked(1 + (capacity.as_u64() / t.as_u64()) as u32) };
         let replenish_1_per = t.into();
         Quota {
             max_burst,

--- a/governor/src/state/direct/sinks.rs
+++ b/governor/src/state/direct/sinks.rs
@@ -152,13 +152,12 @@ impl<
 }
 
 impl<
-        'a,
         Item,
         S: Sink<Item>,
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
         MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
-    > Sink<Item> for RatelimitedSink<'a, Item, S, D, C, MW>
+    > Sink<Item> for RatelimitedSink<'_, Item, S, D, C, MW>
 where
     S: Unpin,
     Item: Unpin,
@@ -230,13 +229,12 @@ where
 
 /// Pass-through implementation for [`futures_util::Stream`] if the Sink also implements it.
 impl<
-        'a,
         Item,
         S: Stream + Sink<Item>,
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
         MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
-    > Stream for RatelimitedSink<'a, Item, S, D, C, MW>
+    > Stream for RatelimitedSink<'_, Item, S, D, C, MW>
 where
     S::Item: Unpin,
     S: Unpin,

--- a/governor/src/state/direct/streams.rs
+++ b/governor/src/state/direct/streams.rs
@@ -115,13 +115,8 @@ pub struct RatelimitedStream<
 }
 
 /// Conversion methods for the stream combinator.
-impl<
-        'a,
-        S: Stream,
-        D: DirectStateStore,
-        C: clock::Clock,
-        MW: RateLimitingMiddleware<C::Instant>,
-    > RatelimitedStream<'a, S, D, C, MW>
+impl<S: Stream, D: DirectStateStore, C: clock::Clock, MW: RateLimitingMiddleware<C::Instant>>
+    RatelimitedStream<'_, S, D, C, MW>
 {
     /// Acquires a reference to the underlying stream that this combinator is pulling from.
     /// ```rust
@@ -173,8 +168,8 @@ impl<
 }
 
 /// Implements the [`futures_util::Stream`] combinator.
-impl<'a, S: Stream, D: DirectStateStore, C: clock::Clock, MW> Stream
-    for RatelimitedStream<'a, S, D, C, MW>
+impl<S: Stream, D: DirectStateStore, C: clock::Clock, MW> Stream
+    for RatelimitedStream<'_, S, D, C, MW>
 where
     S: Unpin,
     S::Item: Unpin,
@@ -241,13 +236,12 @@ where
 
 /// Pass-through implementation for [`futures_util::Sink`] if the Stream also implements it.
 impl<
-        'a,
         Item,
         S: Stream + Sink<Item>,
         D: DirectStateStore,
         C: clock::Clock,
         MW: RateLimitingMiddleware<C::Instant>,
-    > Sink<Item> for RatelimitedStream<'a, S, D, C, MW>
+    > Sink<Item> for RatelimitedStream<'_, S, D, C, MW>
 where
     S: Unpin,
     S::Item: Unpin,

--- a/governor/src/state/keyed.rs
+++ b/governor/src/state/keyed.rs
@@ -182,7 +182,7 @@ where
         // arrival time is larger than a starting state for the bucket gets to stay, everything
         // else (that's indistinguishable from a starting state) goes.
         let now = self.clock.now();
-        let drop_below = now.duration_since(self.start);
+        let drop_below = now.duration_since(self.start).saturating_sub(self.gcra.t());
 
         self.state.retain_recent(drop_below);
     }

--- a/governor/tests/direct.rs
+++ b/governor/tests/direct.rs
@@ -127,8 +127,10 @@ fn all_capacity_check_rejects_excess() {
     let lb = RateLimiter::direct_with_clock(Quota::per_second(nonzero!(5u32)), clock);
 
     assert_eq!(Err(InsufficientCapacity(5)), lb.check_n(nonzero!(15u32)));
-    assert_eq!(Err(InsufficientCapacity(5)), lb.check_n(nonzero!(6u32)));
     assert_eq!(Err(InsufficientCapacity(5)), lb.check_n(nonzero!(7u32)));
+    assert_eq!(Err(InsufficientCapacity(5)), lb.check_n(nonzero!(6u32)));
+
+    assert_eq!(Ok(Ok(())), lb.check_n(nonzero!(5u32)));
 }
 
 #[test]

--- a/governor/tests/middleware.rs
+++ b/governor/tests/middleware.rs
@@ -90,7 +90,6 @@ fn state_snapshot_tracks_quota_accurately() {
     assert_eq!(lim.check().map_err(|_| ()), Err(()), "should rate limit");
 
     clock.advance(Duration::from_secs(120));
-    assert_eq!(lim.check().map(|s| s.remaining_burst_capacity()), Ok(2));
     assert_eq!(lim.check().map(|s| s.remaining_burst_capacity()), Ok(1));
     assert_eq!(lim.check().map(|s| s.remaining_burst_capacity()), Ok(0));
     assert_eq!(lim.check().map_err(|_| ()), Err(()), "should rate limit");


### PR DESCRIPTION
In GCRA terms, the total capacity of the rate limiter is `Τ + τ`, where `Τ` is the nominal cell arrival interval and `τ` is (extra) tolerance allowed for bursts.

The current implementation has a subtle issue, caused by conflating capacity and tolerance, which results in one extra cell being allowed after arrival intervals equal or greater than "capacity + 1", as reported in https://github.com/boinkor-net/governor/issues/107 and https://github.com/boinkor-net/governor/issues/249. The problem was partially hidden in other cases by a compensating addition of `Τ` to initial `TAT` in the case of the first cell (i.e. when the rate limiter has no state recorded for it).

To fix the issue, correct the value `tau` used for making the decision, making it the tolerance and not the capacity, and remove the compensation for the first cell that's no longer necessary.

This PR also adds a new specific test for the "capacity + 1" interval scenario, as well as fixes an existing test that incorrectly expected one of these extra cells. Finally, some needless lifetimes reported by clippy are also removed since the project opts for `#[deny(warnings)]`.

Fixes: https://github.com/boinkor-net/governor/issues/107
Fixes: https://github.com/boinkor-net/governor/issues/249