### PR TITLE
Add WASM support

### DIFF
--- a/governor/Cargo.toml
+++ b/governor/Cargo.toml
@@ -53,6 +53,7 @@ futures-timer = { version = "3.0.3", optional = true }
 futures-util = { version = "0.3.31", optional = true, default-features = false, features = ["std", "sink"] }
 futures-sink = { version = "0.3.31", optional = true }
 rand = { version = "0.8.0", optional = true }
+getrandom = { version = "0.2", features = ["js"] }
 dashmap = { version = "6.1.0", optional = true }
 quanta = { version = "0.12.0", optional = true }
 no-std-compat = { version = "0.4.1", features = [ "alloc" ] }
@@ -60,3 +61,4 @@ cfg-if = "1.0"
 
 # To ensure we don't pull in vulnerable smallvec, see https://github.com/antifuchs/governor/issues/60
 smallvec = "1.6.1"
+web-time = "1.1.0"

--- a/governor/src/clock/with_std.rs
+++ b/governor/src/clock/with_std.rs
@@ -4,7 +4,9 @@ use std::prelude::v1::*;
 
 use crate::nanos::Nanos;
 use std::ops::Add;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
+use web_time::Instant;
+
 
 /// The monotonic clock implemented by [`Instant`].
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
Closes #34!

This was a bit of a rabbit hole to get into, even though the changes are (thankfully) tiny but this adds WASM support to the crate. My use case was using a downstream crate in Cloudflare workers and this crate was causing panics because of its time APIs.

The PR uses [`web-time`](https://crates.io/crates/web-time) which was made specifically for this purpose; [`MonotonicClock`](https://docs.rs/governor/latest/governor/clock/struct.MonotonicClock.html) is now compatible with WASM environments at, *from what I understand*, no extra cost to non-WASM environments. 

> At the same time the library will simply re-export [std::time](https://doc.rust-lang.org/stable/std/time/) when not using the wasm32-unknown-unknown target and will not pull in any dependencies. 

^ From web-time's README

One small point that might cause confusion is when trying to type out a `RateLimiter` type which can look something like
`limiter: Arc<RateLimiter<NotKeyed, InMemoryState, MonotonicClock, NoOpMiddleware<web_time::Instant>>>`. If someone accidentally uses `std::time::Instant`, the errors are about Instant not implementing the traits that are outlined [here](https://docs.rs/governor/latest/governor/clock/index.html) which can be confusing to those trying to use this. For this I think for one documenting this use case is a must but also re-exporting `web_time::Instant` should come in handy.

My reasoning for the above is that while the existing docs are good and self explanatory, only someone that would try implementing his own Clock would likely take a look there; since this is an existing, internal Clock provided by the crate, there's a good chance most people using it won't have read that part of the docs.

You will also notice this PR adds `getrandom = { version = "0.2", features = ["js"] }`, this is required to get `rand` to compile in a WASM environment (see [here](https://github.com/rust-random/rand?tab=readme-ov-file#wasm-support)).

Lastly, nothing of the included changes is put behind a feature flag but I personally don't think any of the changes could cause issues. Let me know what you think!