### PR TITLE
Fix typo

### DIFF
--- a/governor/src/_guide.rs
+++ b/governor/src/_guide.rs
@@ -50,7 +50,7 @@
 //! # } #[cfg(not(feature = "std"))] fn main() {}
 //! ```
 //!
-//! In `no_std` mode, there are is no default monotonic (or system)
+//! In `no_std` mode, there is no default monotonic (or system)
 //! clock available. To effectively limit rates, you will have to
 //! either use the provided "fake" clock (which must be manually
 //! advanced, and is mainly useful for tests), or implement the


### PR DESCRIPTION
Just noticed a small typo [here](https://docs.rs/governor/latest/governor/_guide/index.html#constructing-a-direct-rate-limiter)

> In `no_std` mode, there *are* is no default monotonic...
