### PR TITLE
Get rid of no_std_compat

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ allow = [
     "BSD-2-Clause",
     "MIT",
     "Unicode-DFS-2016",
+    "Zlib",
 ]
 confidence-threshold = 0.8
 

--- a/governor/CHANGELOG.md
+++ b/governor/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+## Changed
+
+- Governor no longer uses the
+  [`no_std_compat` crate](https://crates.io/crates/no-std-compat),
+  eliminating a very outdated transitive dependency (on `hashbrown`
+  version 0.8).
+
 ## [[0.8.1](https://docs.rs/governor/0.8.1/governor/)] - 2025-02-25
 
 ## Changed

--- a/governor/Cargo.toml
+++ b/governor/Cargo.toml
@@ -40,9 +40,9 @@ assertables = "9.5.0"
 [features]
 default = ["std", "dashmap", "jitter", "quanta"]
 quanta = ["dep:quanta"]
-std = ["no-std-compat/std", "nonzero_ext/std", "dep:futures-timer", "dep:futures-util", "dep:futures-sink", "dep:parking_lot"]
+std = ["nonzero_ext/std", "dep:futures-timer", "dep:futures-util", "dep:futures-sink", "dep:parking_lot"]
 jitter = ["rand"]
-no_std = ["no-std-compat/compat_hash"]
+no_std = ["hashbrown/alloc"]
 
 [dependencies]
 nonzero_ext = { version = "0.3.0", default-features = false }
@@ -56,9 +56,9 @@ rand = { version = "0.9.0", optional = true }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 dashmap = { version = "6.1.0", optional = true }
 quanta = { version = "0.12.0", optional = true }
-no-std-compat = { version = "0.4.1", features = [ "alloc" ] }
 cfg-if = "1.0"
 
 # To ensure we don't pull in vulnerable smallvec, see https://github.com/antifuchs/governor/issues/60
 smallvec = "1.6.1"
 web-time = "1.1.0"
+hashbrown = "0.15.2"

--- a/governor/src/clock.rs
+++ b/governor/src/clock.rs
@@ -44,14 +44,14 @@
 //! }
 //! ```
 
-use std::prelude::v1::*;
+use core::prelude::v1::*;
 
-use std::convert::TryInto;
-use std::fmt::Debug;
-use std::ops::Add;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::time::Duration;
+use alloc::sync::Arc;
+use core::convert::TryInto;
+use core::fmt::Debug;
+use core::ops::Add;
+use core::sync::atomic::Ordering;
+use core::time::Duration;
 
 use portable_atomic::AtomicU64;
 

--- a/governor/src/errors.rs
+++ b/governor/src/errors.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 /// Error indicating that the number of cells tested (the first
 /// argument) is larger than the bucket's capacity.

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -2,9 +2,9 @@ use crate::state::StateStore;
 use crate::InsufficientCapacity;
 use crate::{clock, middleware::StateSnapshot, Quota};
 use crate::{middleware::RateLimitingMiddleware, nanos::Nanos};
-use std::num::NonZeroU32;
-use std::time::Duration;
-use std::{cmp, fmt};
+use core::num::NonZeroU32;
+use core::time::Duration;
+use core::{cmp, fmt};
 
 #[cfg(feature = "std")]
 use crate::Jitter;
@@ -181,7 +181,7 @@ impl Gcra {
 mod test {
     use super::*;
     use crate::Quota;
-    use std::num::NonZeroU32;
+    use core::num::NonZeroU32;
 
     use proptest::prelude::*;
 

--- a/governor/src/jitter.rs
+++ b/governor/src/jitter.rs
@@ -1,14 +1,12 @@
-use std::prelude::v1::*;
-
 use crate::nanos::Nanos;
+use core::ops::Add;
+use core::time::Duration;
 #[cfg(feature = "jitter")]
 use rand::distr::uniform::{SampleBorrow, SampleUniform, UniformInt, UniformSampler};
 #[cfg(feature = "jitter")]
 use rand::distr::{Distribution, Uniform};
 #[cfg(feature = "jitter")]
 use rand::{rng, Rng};
-use std::ops::Add;
-use std::time::Duration;
 
 #[cfg(feature = "std")]
 use std::time::Instant;

--- a/governor/src/lib.rs
+++ b/governor/src/lib.rs
@@ -35,7 +35,7 @@
 // Unfortunately necessary, otherwise features aren't supported in doctests:
 #![allow(clippy::needless_doctest_main)]
 
-extern crate no_std_compat as std;
+extern crate alloc;
 
 pub mod r#_guide;
 pub mod clock;

--- a/governor/src/middleware.rs
+++ b/governor/src/middleware.rs
@@ -64,7 +64,7 @@
 //!
 //! You can define your own middleware by `impl`ing [`RateLimitingMiddleware`].
 use core::fmt;
-use std::{cmp, marker::PhantomData};
+use core::{cmp, marker::PhantomData};
 
 use crate::{clock, nanos::Nanos, NotUntil, Quota};
 
@@ -219,7 +219,7 @@ pub struct NoOpMiddleware<P: clock::Reference = <clock::DefaultClock as clock::C
     phantom: PhantomData<P>,
 }
 
-impl<P: clock::Reference> std::fmt::Debug for NoOpMiddleware<P> {
+impl<P: clock::Reference> core::fmt::Debug for NoOpMiddleware<P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "NoOpMiddleware")
     }

--- a/governor/src/nanos.rs
+++ b/governor/src/nanos.rs
@@ -2,11 +2,10 @@
 
 use crate::clock;
 
-use std::convert::TryInto;
-use std::fmt;
-use std::ops::{Add, Div, Mul};
-use std::prelude::v1::*;
-use std::time::Duration;
+use core::convert::TryInto;
+use core::fmt;
+use core::ops::{Add, Div, Mul};
+use core::time::Duration;
 
 /// A number of nanoseconds from a reference point.
 ///

--- a/governor/src/quota.rs
+++ b/governor/src/quota.rs
@@ -1,8 +1,6 @@
-use std::prelude::v1::*;
-
+use core::num::NonZeroU32;
+use core::time::Duration;
 use nonzero_ext::nonzero;
-use std::num::NonZeroU32;
-use std::time::Duration;
 
 use crate::nanos::Nanos;
 

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -1,6 +1,6 @@
 //! State stores for rate limiters
 
-use std::{marker::PhantomData, prelude::v1::*};
+use core::marker::PhantomData;
 
 pub mod direct;
 mod in_memory;

--- a/governor/src/state/direct.rs
+++ b/governor/src/state/direct.rs
@@ -3,9 +3,7 @@
 //! Rate limiters based on these types are constructed with
 //! [the `RateLimiter` constructors](../struct.RateLimiter.html#direct-in-memory-rate-limiters---constructors)
 
-use std::prelude::v1::*;
-
-use std::num::NonZeroU32;
+use core::num::NonZeroU32;
 
 use crate::{
     clock,

--- a/governor/src/state/in_memory.rs
+++ b/governor/src/state/in_memory.rs
@@ -1,12 +1,10 @@
-use std::prelude::v1::*;
-
 use crate::nanos::Nanos;
 use crate::state::{NotKeyed, StateStore};
-use std::fmt;
-use std::fmt::Debug;
-use std::num::NonZeroU64;
-use std::sync::atomic::Ordering;
-use std::time::Duration;
+use core::fmt;
+use core::fmt::Debug;
+use core::num::NonZeroU64;
+use core::sync::atomic::Ordering;
+use core::time::Duration;
 
 use portable_atomic::AtomicU64;
 
@@ -135,6 +133,7 @@ mod test {
 
     #[test]
     fn in_memory_state_impls() {
+        use alloc::format;
         let state = InMemoryState(AtomicU64::new(0));
         assert_gt!(format!("{:?}", state).len(), 0);
     }

--- a/governor/src/state/keyed.rs
+++ b/governor/src/state/keyed.rs
@@ -7,9 +7,9 @@
 //! Rate limiters based on these types are constructed with
 //! [the `RateLimiter` constructors](../struct.RateLimiter.html#keyed-rate-limiters---default-constructors)
 
-use std::hash::Hash;
-use std::num::NonZeroU32;
-use std::prelude::v1::*;
+use core::hash::Hash;
+use core::num::NonZeroU32;
+use core::prelude::v1::*;
 
 use crate::state::StateStore;
 use crate::{
@@ -233,7 +233,7 @@ pub type DefaultKeyedStateStore<K> = DashMapStateStore<K>;
 
 #[cfg(test)]
 mod test {
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
 
     use nonzero_ext::nonzero;
 

--- a/governor/src/state/keyed/dashmap.rs
+++ b/governor/src/state/keyed/dashmap.rs
@@ -1,13 +1,11 @@
 #![cfg(all(feature = "std", feature = "dashmap"))]
 
-use std::prelude::v1::*;
-
 use crate::nanos::Nanos;
 use crate::state::{InMemoryState, StateStore};
 use crate::{clock, Quota, RateLimiter};
 use crate::{middleware::NoOpMiddleware, state::keyed::ShrinkableKeyedStateStore};
+use core::hash::Hash;
 use dashmap::DashMap;
-use std::hash::Hash;
 
 /// A concurrent, thread-safe and fairly performant hashmap based on [`DashMap`].
 pub type DashMapStateStore<K> = DashMap<K, InMemoryState>;

--- a/governor/src/state/keyed/future.rs
+++ b/governor/src/state/keyed/future.rs
@@ -1,11 +1,9 @@
-use std::prelude::v1::*;
-
 use crate::{
     clock, errors::InsufficientCapacity, middleware::RateLimitingMiddleware,
     state::keyed::KeyedStateStore, Jitter, NotUntil, RateLimiter,
 };
+use core::{hash::Hash, num::NonZeroU32};
 use futures_timer::Delay;
-use std::{hash::Hash, num::NonZeroU32};
 
 #[cfg(feature = "std")]
 /// # Keyed rate limiters - `async`/`await`

--- a/governor/src/state/keyed/hashmap.rs
+++ b/governor/src/state/keyed/hashmap.rs
@@ -1,13 +1,11 @@
-use std::prelude::v1::*;
-
 use crate::nanos::Nanos;
 use crate::{clock, Quota, RateLimiter};
 use crate::{
     middleware::NoOpMiddleware,
     state::{InMemoryState, StateStore},
 };
-use std::collections::HashMap;
-use std::hash::Hash;
+use core::hash::Hash;
+use hashbrown::HashMap;
 
 use crate::state::keyed::ShrinkableKeyedStateStore;
 


### PR DESCRIPTION
It's super outdated, pulls in an ancient version of hashbrown and that blocks #262. Let's get rid of this.