### PR TITLE
Build `Quota` from a human readable string

### DIFF
--- a/governor/Cargo.toml
+++ b/governor/Cargo.toml
@@ -62,3 +62,5 @@ cfg-if = "1.0"
 smallvec = "1.6.1"
 web-time = "1.1.0"
 hashbrown = "0.15.2"
+once_cell = { version = "1.21.3", default-features = false, features = ["alloc"] }
+regex = { version = "1.11.1", default-features = false, features = ["perf", "unicode"] }


### PR DESCRIPTION
As a consumer of this library, we had a use-case where we wanted to build `Quota` using human readable strings like `5 per second` or `30 per minute`. This PR aims to implement that feature. The implementation is heavily inspired from [limits](https://limits.readthedocs.io/en/stable/) library from Python.