### PR TITLE
Refactor the middleware, add a crate governor-tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
+resolver = "3"
 
 members = [
   # Ordering here apparently defines release order:
-  "governor",
+  "governor", "governor-tracing",
 ]

--- a/governor-tracing/Cargo.toml
+++ b/governor-tracing/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "governor-tracing"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+governor = { version = "0.10.0", path = "../governor" }
+tracing = "0.1.41"

--- a/governor-tracing/src/lib.rs
+++ b/governor-tracing/src/lib.rs
@@ -1,0 +1,40 @@
+use std::{fmt::Debug, marker::PhantomData};
+
+use governor::{clock, middleware::RateLimitingMiddleware};
+use tracing::instrument;
+
+/// Middleware that emits `TRACE` level events whenever a measurement and outcome on the ratelimiter happens.
+#[derive(Debug)]
+pub struct TracingMiddleware<K: Debug, P: clock::Reference, I: RateLimitingMiddleware<P, Key = K>> {
+    _phantom: PhantomData<(K, I, P)>,
+}
+
+impl<K: Debug, P: clock::Reference, I: RateLimitingMiddleware<P, Key = K>> RateLimitingMiddleware<P>
+    for TracingMiddleware<K, P, I>
+where
+    I::PositiveOutcome: Debug,
+    I::NegativeOutcome: Debug,
+{
+    type PositiveOutcome = I::PositiveOutcome;
+
+    type NegativeOutcome = I::NegativeOutcome;
+
+    type Key = K;
+
+    #[instrument(ret, skip(state))]
+    fn allow(
+        key: &Self::Key,
+        state: impl Into<governor::middleware::StateSnapshot>,
+    ) -> Self::PositiveOutcome {
+        I::allow(key, state)
+    }
+
+    #[instrument(ret, skip(limiter))]
+    fn disallow(
+        key: &Self::Key,
+        limiter: impl Into<governor::middleware::StateSnapshot>,
+        start_time: P,
+    ) -> Self::NegativeOutcome {
+        I::disallow(key, limiter, start_time)
+    }
+}

--- a/governor/CHANGELOG.md
+++ b/governor/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- The `RateLimitingMiddleware` type now requires an associated type, `Key`,
+  and its `allow` and `disallow` associated functions have lost their
+  generic `<K>` argument.
+
+  This is a breaking change, meaning that the explicit type signatures
+  in code that doesn't use the `DefaultDirectRateLimiter` or
+  `DefaultKeyedRateLimiter` now need to change, but it allows implementors
+  of middleware to restrict key types, e.g. to ensure they are `Debug`.
+
 ## [[0.10.0](https://docs.rs/governor/0.10.0/governor/)] - 2025-03-27
 
 ## Changed

--- a/governor/benches/multi_threaded.rs
+++ b/governor/benches/multi_threaded.rs
@@ -65,7 +65,7 @@ fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mu
 
         b.iter_custom(|iters| {
             let state: M = Default::default();
-            let lim: Arc<RateLimiter<_, _, _, NoOpMiddleware>> = Arc::new(RateLimiter::new(
+            let lim: Arc<RateLimiter<_, _, _, NoOpMiddleware<u32>>> = Arc::new(RateLimiter::new(
                 Quota::per_second(nonzero!(50u32)),
                 state,
                 clock.clone(),

--- a/governor/benches/single_threaded.rs
+++ b/governor/benches/single_threaded.rs
@@ -47,7 +47,7 @@ fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mu
                 _,
                 _,
                 _,
-                NoOpMiddleware<<clock::FakeRelativeClock as clock::Clock>::Instant>,
+                NoOpMiddleware<u32, <clock::FakeRelativeClock as clock::Clock>::Instant>,
             > = RateLimiter::new(Quota::per_second(nonzero!(50u32)), state, clock.clone());
             b.iter_batched(
                 || {

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -101,7 +101,7 @@ impl Gcra {
         K,
         P: clock::Reference,
         S: StateStore<Key = K>,
-        MW: RateLimitingMiddleware<P>,
+        MW: RateLimitingMiddleware<P, Key = K>,
     >(
         &self,
         start: P,
@@ -136,7 +136,7 @@ impl Gcra {
         K,
         P: clock::Reference,
         S: StateStore<Key = K>,
-        MW: RateLimitingMiddleware<P>,
+        MW: RateLimitingMiddleware<P, Key = K>,
     >(
         &self,
         start: P,

--- a/governor/src/lib.rs
+++ b/governor/src/lib.rs
@@ -74,7 +74,10 @@ pub mod prelude {
 ///
 /// See the [`RateLimiter`] documentation for details.
 pub type DefaultDirectRateLimiter<
-    MW = middleware::NoOpMiddleware<<clock::DefaultClock as clock::Clock>::Instant>,
+    MW = middleware::NoOpMiddleware<
+        state::direct::NotKeyed,
+        <clock::DefaultClock as clock::Clock>::Instant,
+    >,
 > = RateLimiter<state::direct::NotKeyed, state::InMemoryState, clock::DefaultClock, MW>;
 
 /// A rate limiter with one state per key, running on the default clock.
@@ -82,6 +85,6 @@ pub type DefaultDirectRateLimiter<
 /// See the [`RateLimiter`] documentation for details.
 pub type DefaultKeyedRateLimiter<
     K,
-    MW = middleware::NoOpMiddleware<<clock::DefaultClock as clock::Clock>::Instant>,
+    MW = middleware::NoOpMiddleware<K, <clock::DefaultClock as clock::Clock>::Instant>,
     S = state::keyed::DefaultHasher,
 > = RateLimiter<K, state::keyed::DefaultKeyedStateStore<K, S>, clock::DefaultClock, MW>;

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -54,7 +54,7 @@ pub trait StateStore {
 /// period) and the concrete state of rate limiting decisions. This crate ships in-memory state
 /// stores, but it's possible (by implementing the [`StateStore`] trait) to make others.
 #[derive(Debug)]
-pub struct RateLimiter<K, S, C, MW = NoOpMiddleware>
+pub struct RateLimiter<K, S, C, MW = NoOpMiddleware<K>>
 where
     S: StateStore<Key = K>,
     C: clock::Clock,

--- a/governor/src/state/direct.rs
+++ b/governor/src/state/direct.rs
@@ -38,17 +38,17 @@ impl<T> DirectStateStore for T where T: StateStore<Key = NotKeyed> {}
 /// or to ensure that an API client stays within a service's rate
 /// limit.
 #[cfg(feature = "std")]
-impl RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock, NoOpMiddleware> {
+impl RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock, NoOpMiddleware<NotKeyed>> {
     /// Constructs a new in-memory direct rate limiter for a quota with the default real-time clock.
     pub fn direct(
         quota: Quota,
-    ) -> RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock, NoOpMiddleware> {
+    ) -> RateLimiter<NotKeyed, InMemoryState, clock::DefaultClock, NoOpMiddleware<NotKeyed>> {
         let clock = clock::DefaultClock::default();
         Self::direct_with_clock(quota, clock)
     }
 }
 
-impl<C> RateLimiter<NotKeyed, InMemoryState, C, NoOpMiddleware<C::Instant>>
+impl<C> RateLimiter<NotKeyed, InMemoryState, C, NoOpMiddleware<NotKeyed, C::Instant>>
 where
     C: clock::Clock,
 {
@@ -64,7 +64,7 @@ impl<S, C, MW> RateLimiter<NotKeyed, S, C, MW>
 where
     S: DirectStateStore,
     C: clock::Clock,
-    MW: RateLimitingMiddleware<C::Instant>,
+    MW: RateLimitingMiddleware<C::Instant, Key = NotKeyed>,
 {
     /// Allow a single cell through the rate limiter.
     ///

--- a/governor/src/state/direct/future.rs
+++ b/governor/src/state/direct/future.rs
@@ -16,7 +16,7 @@ impl<S, C, MW> RateLimiter<NotKeyed, S, C, MW>
 where
     S: DirectStateStore,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>, Key = NotKeyed>,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/governor/src/state/direct/sinks.rs
+++ b/governor/src/state/direct/sinks.rs
@@ -156,7 +156,7 @@ impl<
         S: Sink<Item>,
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>, Key = NotKeyed>,
     > Sink<Item> for RatelimitedSink<'_, Item, S, D, C, MW>
 where
     S: Unpin,

--- a/governor/src/state/direct/streams.rs
+++ b/governor/src/state/direct/streams.rs
@@ -175,7 +175,7 @@ where
     S::Item: Unpin,
     Self: Unpin,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>, Key = NotKeyed>,
 {
     type Item = S::Item;
 

--- a/governor/src/state/keyed.rs
+++ b/governor/src/state/keyed.rs
@@ -136,7 +136,7 @@ where
     S: KeyedStateStore<K>,
     K: Hash,
     C: clock::Clock,
-    MW: RateLimitingMiddleware<C::Instant>,
+    MW: RateLimitingMiddleware<C::Instant, Key = K>,
 {
     /// Allow a single cell through the rate limiter for the given key.
     ///
@@ -329,7 +329,7 @@ mod test {
             u32,
             NaiveKeyedStateStore<u32>,
             FakeRelativeClock,
-            NoOpMiddleware<<FakeRelativeClock as Clock>::Instant>,
+            NoOpMiddleware<u32, <FakeRelativeClock as Clock>::Instant>,
         > = RateLimiter::new(
             Quota::per_second(nonzero!(1_u32)),
             NaiveKeyedStateStore::default(),

--- a/governor/src/state/keyed/dashmap.rs
+++ b/governor/src/state/keyed/dashmap.rs
@@ -33,7 +33,7 @@ impl<K: Hash + Eq + Clone, S: core::hash::BuildHasher + Clone> StateStore
 }
 
 /// # Keyed rate limiters - [`DashMap`]-backed with a default hasher
-impl<K, C> RateLimiter<K, DashMapStateStore<K>, C, NoOpMiddleware<C::Instant>>
+impl<K, C> RateLimiter<K, DashMapStateStore<K>, C, NoOpMiddleware<K, C::Instant>>
 where
     K: Hash + Eq + Clone,
     C: clock::Clock,
@@ -47,7 +47,7 @@ where
 }
 
 /// # Keyed rate limiters - [`DashMap`]-backed with a custom hasher
-impl<K, S, C> RateLimiter<K, DashMapStateStore<K, S>, C, NoOpMiddleware<C::Instant>>
+impl<K, S, C> RateLimiter<K, DashMapStateStore<K, S>, C, NoOpMiddleware<K, C::Instant>>
 where
     K: Hash + Eq + Clone,
     S: core::hash::BuildHasher + Default + Clone,

--- a/governor/src/state/keyed/future.rs
+++ b/governor/src/state/keyed/future.rs
@@ -12,7 +12,7 @@ where
     K: Hash + Eq + Clone,
     S: KeyedStateStore<K>,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>, Key = K>,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/governor/src/state/keyed/hashmap.rs
+++ b/governor/src/state/keyed/hashmap.rs
@@ -68,7 +68,7 @@ impl<K: Hash + Eq + Clone, S: core::hash::BuildHasher> ShrinkableKeyedStateStore
 }
 
 /// # Keyed rate limiters - [`HashMap`]-backed with a default hasher
-impl<K, C> RateLimiter<K, HashMapStateStore<K>, C, NoOpMiddleware<C::Instant>>
+impl<K, C> RateLimiter<K, HashMapStateStore<K>, C, NoOpMiddleware<K, C::Instant>>
 where
     K: Hash + Eq + Clone,
     C: clock::Clock,
@@ -81,7 +81,7 @@ where
 }
 
 /// # Keyed rate limiters - [`HashMap`]-backed with a custom hasher
-impl<K, S, C> RateLimiter<K, HashMapStateStore<K, S>, C, NoOpMiddleware<C::Instant>>
+impl<K, S, C> RateLimiter<K, HashMapStateStore<K, S>, C, NoOpMiddleware<K, C::Instant>>
 where
     K: Hash + Eq + Clone,
     S: core::hash::BuildHasher,

--- a/governor/tests/direct.rs
+++ b/governor/tests/direct.rs
@@ -193,13 +193,14 @@ fn default_direct() {
 fn stresstest_large_quotas() {
     use std::{sync::Arc, thread};
 
-    use governor::middleware::StateInformationMiddleware;
+    use governor::{middleware::StateInformationMiddleware, state::NotKeyed};
 
     let quota = Quota::per_second(nonzero!(1_000_000_001u32));
-    let rate_limiter =
-        Arc::new(RateLimiter::direct(quota).with_middleware::<StateInformationMiddleware>());
+    let rate_limiter = Arc::new(
+        RateLimiter::direct(quota).with_middleware::<StateInformationMiddleware<NotKeyed>>(),
+    );
 
-    fn rlspin(rl: Arc<DefaultDirectRateLimiter<StateInformationMiddleware>>) {
+    fn rlspin(rl: Arc<DefaultDirectRateLimiter<StateInformationMiddleware<NotKeyed>>>) {
         for _ in 0..1_000_000 {
             rl.check().map_err(|e| dbg!(e)).unwrap();
         }

--- a/governor/tests/keyed_dashmap.rs
+++ b/governor/tests/keyed_dashmap.rs
@@ -52,7 +52,7 @@ fn retained_keys<T: Clone + Hash + Eq + Copy + Ord>(
         T,
         DashMapStateStore<T>,
         FakeRelativeClock,
-        NoOpMiddleware<<FakeRelativeClock as Clock>::Instant>,
+        NoOpMiddleware<T, <FakeRelativeClock as Clock>::Instant>,
     >,
 ) -> Vec<T> {
     let state = limiter.into_state_store();

--- a/governor/tests/keyed_hashmap.rs
+++ b/governor/tests/keyed_hashmap.rs
@@ -49,7 +49,7 @@ fn retained_keys<T: Clone + Hash + Eq + Copy + Ord>(
         T,
         HashMapStateStore<T>,
         FakeRelativeClock,
-        NoOpMiddleware<<FakeRelativeClock as Clock>::Instant>,
+        NoOpMiddleware<T, <FakeRelativeClock as Clock>::Instant>,
     >,
 ) -> Vec<T> {
     let state = limiter.into_state_store();


### PR DESCRIPTION
This PR adds a middleware that one can use to debug the behavior and flow of operations in a rate limiter. To do that, I had to refactor the RateLimitingMiddleware trait such that:

* The middleware trait takes a `Key` associated type, indicating the key type being used. That allows restricting the key as `Debug` in governor-tracing.
* The `allow` and `disallow` methods no longer take a `K` type argument

Not sure that this refactoring is necessary or desireable; maybe I can get by without it.