### PR TITLE
Enable middleware support for different quotas per key.

### DIFF
--- a/governor/Cargo.toml
+++ b/governor/Cargo.toml
@@ -36,6 +36,7 @@ libc = "0.2.70"
 futures-executor = "0.3.31"
 proptest = "1.0.0"
 assertables = "9.5.0"
+nonzero = "0.2.0"
 
 [features]
 default = ["std", "dashmap", "jitter", "quanta"]

--- a/governor/benches/multi_threaded.rs
+++ b/governor/benches/multi_threaded.rs
@@ -69,6 +69,7 @@ fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mu
                 Quota::per_second(nonzero!(50u32)),
                 state,
                 clock.clone(),
+                NoOpMiddleware::default(),
             ));
 
             let mut children = vec![];

--- a/governor/benches/single_threaded.rs
+++ b/governor/benches/single_threaded.rs
@@ -48,7 +48,12 @@ fn bench_keyed<M: KeyedStateStore<u32> + Default + Send + Sync + 'static>(c: &mu
                 _,
                 _,
                 NoOpMiddleware<<clock::FakeRelativeClock as clock::Clock>::Instant>,
-            > = RateLimiter::new(Quota::per_second(nonzero!(50u32)), state, clock.clone());
+            > = RateLimiter::new(
+                Quota::per_second(nonzero!(50u32)),
+                state,
+                clock.clone(),
+                NoOpMiddleware::default(),
+            );
             b.iter_batched(
                 || {
                     clock.advance(step);

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -70,7 +70,7 @@ pub struct NotUntil<P: clock::Reference> {
 impl<P: clock::Reference> NotUntil<P> {
     /// Create a `NotUntil` as a negative rate-limiting result.
     #[inline]
-    pub(crate) fn new(state: StateSnapshot, start: P) -> Self {
+    pub fn new(state: StateSnapshot, start: P) -> Self {
         Self { state, start }
     }
 

--- a/governor/src/gcra.rs
+++ b/governor/src/gcra.rs
@@ -1,6 +1,6 @@
 use crate::state::StateStore;
 use crate::InsufficientCapacity;
-use crate::{clock, middleware::StateSnapshot, Quota};
+use crate::{clock, Quota};
 use crate::{middleware::RateLimitingMiddleware, nanos::Nanos};
 use core::num::NonZeroU32;
 use core::time::Duration;
@@ -8,6 +8,54 @@ use core::{cmp, fmt};
 
 #[cfg(feature = "std")]
 use crate::Jitter;
+
+/// Information about the rate-limiting state used to reach a decision.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StateSnapshot {
+    /// The "weight" of a single packet in units of time.
+    t: Nanos,
+
+    /// The "tolerance" of the bucket.
+    ///
+    /// The total "burst capacity" of the bucket is `t + tau`.
+    tau: Nanos,
+
+    /// The time at which the measurement was taken.
+    pub(crate) time_of_measurement: Nanos,
+
+    /// The next time a cell is expected to arrive
+    pub(crate) tat: Nanos,
+}
+
+impl StateSnapshot {
+    #[inline]
+    pub(crate) fn new(t: Nanos, tau: Nanos, time_of_measurement: Nanos, tat: Nanos) -> Self {
+        Self {
+            t,
+            tau,
+            time_of_measurement,
+            tat,
+        }
+    }
+
+    /// Returns the quota used to make the rate limiting decision.
+    pub fn quota(&self) -> Quota {
+        Quota::from_gcra_parameters(self.t, self.tau)
+    }
+
+    /// Returns the number of cells that can be let through in
+    /// addition to a (possible) positive outcome.
+    ///
+    /// If this state snapshot is based on a negative rate limiting
+    /// outcome, this method returns 0.
+    pub fn remaining_burst_capacity(&self) -> u32 {
+        let t0 = self.time_of_measurement;
+        (cmp::min(
+            (t0 + self.tau + self.t).saturating_sub(self.tat).as_u64(),
+            (self.tau + self.t).as_u64(),
+        ) / self.t.as_u64()) as u32
+    }
+}
 
 /// A negative rate-limiting outcome.
 ///
@@ -75,7 +123,7 @@ impl<P: clock::Reference> fmt::Display for NotUntil<P> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct Gcra {
+pub struct Gcra {
     /// The "weight" of a single packet in units of time.
     t: Nanos,
 
@@ -86,7 +134,7 @@ pub(crate) struct Gcra {
 }
 
 impl Gcra {
-    pub(crate) fn new(quota: Quota) -> Self {
+    pub fn new(quota: Quota) -> Self {
         let t: Nanos = cmp::max(quota.replenish_1_per, Duration::from_nanos(1)).into();
         let tau: Nanos = t * (quota.max_burst.get() - 1).into();
         Gcra { t, tau }
@@ -101,7 +149,7 @@ impl Gcra {
         K,
         P: clock::Reference,
         S: StateStore<Key = K>,
-        MW: RateLimitingMiddleware<P>,
+        MW: RateLimitingMiddleware<K, P>,
     >(
         &self,
         start: P,
@@ -136,7 +184,7 @@ impl Gcra {
         K,
         P: clock::Reference,
         S: StateStore<Key = K>,
-        MW: RateLimitingMiddleware<P>,
+        MW: RateLimitingMiddleware<K, P>,
     >(
         &self,
         start: P,

--- a/governor/src/lib.rs
+++ b/governor/src/lib.rs
@@ -40,7 +40,7 @@ extern crate alloc;
 pub mod r#_guide;
 pub mod clock;
 mod errors;
-mod gcra;
+pub mod gcra;
 #[cfg(any(feature = "std", feature = "jitter"))]
 mod jitter;
 pub mod middleware;

--- a/governor/src/middleware.rs
+++ b/governor/src/middleware.rs
@@ -63,58 +63,14 @@
 //! ```
 //!
 //! You can define your own middleware by `impl`ing [`RateLimitingMiddleware`].
+use crate::gcra::Gcra;
+use crate::{clock, gcra::StateSnapshot, NotUntil};
 use core::fmt;
-use core::{cmp, marker::PhantomData};
-
-use crate::{clock, nanos::Nanos, NotUntil, Quota};
-
-/// Information about the rate-limiting state used to reach a decision.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct StateSnapshot {
-    /// The "weight" of a single packet in units of time.
-    t: Nanos,
-
-    /// The "tolerance" of the bucket.
-    ///
-    /// The total "burst capacity" of the bucket is `t + tau`.
-    tau: Nanos,
-
-    /// The time at which the measurement was taken.
-    pub(crate) time_of_measurement: Nanos,
-
-    /// The next time a cell is expected to arrive
-    pub(crate) tat: Nanos,
-}
-
-impl StateSnapshot {
-    #[inline]
-    pub(crate) fn new(t: Nanos, tau: Nanos, time_of_measurement: Nanos, tat: Nanos) -> Self {
-        Self {
-            t,
-            tau,
-            time_of_measurement,
-            tat,
-        }
-    }
-
-    /// Returns the quota used to make the rate limiting decision.
-    pub fn quota(&self) -> Quota {
-        Quota::from_gcra_parameters(self.t, self.tau)
-    }
-
-    /// Returns the number of cells that can be let through in
-    /// addition to a (possible) positive outcome.
-    ///
-    /// If this state snapshot is based on a negative rate limiting
-    /// outcome, this method returns 0.
-    pub fn remaining_burst_capacity(&self) -> u32 {
-        let t0 = self.time_of_measurement;
-        (cmp::min(
-            (t0 + self.tau + self.t).saturating_sub(self.tat).as_u64(),
-            (self.tau + self.t).as_u64(),
-        ) / self.t.as_u64()) as u32
-    }
-}
+use core::marker::PhantomData;
+// #[cfg(all(feature = "std", feature = "dashmap"))]
+// use core::time::Duration;
+// #[cfg(all(feature = "std", feature = "dashmap"))]
+// use std::collections::HashMap;
 
 /// Defines the behavior and return values of rate limiting decisions.
 ///
@@ -145,19 +101,20 @@ impl StateSnapshot {
 /// ```rust
 /// # use std::num::NonZeroU32;
 /// # use nonzero_ext::*;
-/// use governor::{middleware::{RateLimitingMiddleware, StateSnapshot},
+/// use governor::{middleware::{RateLimitingMiddleware},
+///                gcra::StateSnapshot,
 ///                Quota, RateLimiter, clock::Reference};
 /// # #[cfg(feature = "std")]
 /// # fn main () {
-/// #[derive(Debug)]
+/// #[derive(Debug, Default)]
 /// struct NullMiddleware;
 ///
-/// impl<P: Reference> RateLimitingMiddleware<P> for NullMiddleware {
+/// impl<K, P: Reference> RateLimitingMiddleware<K, P> for NullMiddleware {
 ///     type PositiveOutcome = ();
 ///     type NegativeOutcome = ();
 ///
-///     fn allow<K>(_key: &K, _state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {}
-///     fn disallow<K>(_: &K, _: impl Into<StateSnapshot>, _: P) -> Self::NegativeOutcome {}
+///     fn allow(_key: &K, _state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {}
+///     fn disallow(_: &K, _: impl Into<StateSnapshot>, _: P) -> Self::NegativeOutcome {}
 /// }
 ///
 /// let lim = RateLimiter::direct(Quota::per_hour(nonzero!(1_u32)))
@@ -169,7 +126,7 @@ impl StateSnapshot {
 /// # #[cfg(not(feature = "std"))]
 /// # fn main() {}
 /// ```
-pub trait RateLimitingMiddleware<P: clock::Reference>: fmt::Debug {
+pub trait RateLimitingMiddleware<K, P: clock::Reference>: fmt::Debug {
     /// The type that's returned by the rate limiter when a cell is allowed.
     ///
     /// By default, rate limiters return `Ok(())`, which does not give
@@ -199,7 +156,7 @@ pub trait RateLimitingMiddleware<P: clock::Reference>: fmt::Debug {
     /// was one cell left in the burst capacity before the decision
     /// was reached, the [`StateSnapshot::remaining_burst_capacity`]
     /// method will return 0.
-    fn allow<K>(key: &K, state: impl Into<StateSnapshot>) -> Self::PositiveOutcome;
+    fn allow(key: &K, state: impl Into<StateSnapshot>) -> Self::PositiveOutcome;
 
     /// Called when a negative rate-limiting decision is made (the
     /// "not allowed but OK" case).
@@ -207,16 +164,30 @@ pub trait RateLimitingMiddleware<P: clock::Reference>: fmt::Debug {
     /// This method returns whatever value is returned inside the
     /// `Err` variant a [`RateLimiter`][crate::RateLimiter]'s check
     /// method returns.
-    fn disallow<K>(
-        key: &K,
-        limiter: impl Into<StateSnapshot>,
-        start_time: P,
-    ) -> Self::NegativeOutcome;
+    fn disallow(key: &K, limiter: impl Into<StateSnapshot>, start_time: P)
+        -> Self::NegativeOutcome;
+
+    /// Called before a rate-limiting decision is made for a given key
+    ///
+    /// This function is designed to allow per-key quotas.
+    ///
+    /// Since it makes no sense for a direct RateLimiter, it is ignored in that case.
+    fn get_quota(&self, _key: &K) -> Option<&Gcra> {
+        None
+    }
 }
 
 /// A middleware that does nothing and returns `()` in the positive outcome.
 pub struct NoOpMiddleware<P: clock::Reference = <clock::DefaultClock as clock::Clock>::Instant> {
     phantom: PhantomData<P>,
+}
+
+impl<P: clock::Reference> core::default::Default for NoOpMiddleware<P> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<P: clock::Reference> core::fmt::Debug for NoOpMiddleware<P> {
@@ -225,7 +196,7 @@ impl<P: clock::Reference> core::fmt::Debug for NoOpMiddleware<P> {
     }
 }
 
-impl<P: clock::Reference> RateLimitingMiddleware<P> for NoOpMiddleware<P> {
+impl<K, P: clock::Reference> RateLimitingMiddleware<K, P> for NoOpMiddleware<P> {
     /// By default, rate limiters return nothing other than an
     /// indicator that the element should be let through.
     type PositiveOutcome = ();
@@ -234,45 +205,39 @@ impl<P: clock::Reference> RateLimitingMiddleware<P> for NoOpMiddleware<P> {
 
     #[inline]
     /// Returns `()` and has no side-effects.
-    fn allow<K>(_key: &K, _state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {}
+    fn allow(_key: &K, _state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {}
 
     #[inline]
     /// Returns the error indicating what
-    fn disallow<K>(
-        _key: &K,
-        state: impl Into<StateSnapshot>,
-        start_time: P,
-    ) -> Self::NegativeOutcome {
+    fn disallow(_key: &K, state: impl Into<StateSnapshot>, start_time: P) -> Self::NegativeOutcome {
         NotUntil::new(state.into(), start_time)
     }
 }
 
 /// Middleware that returns the state of the rate limiter if a
 /// positive decision is reached.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct StateInformationMiddleware;
 
-impl<P: clock::Reference> RateLimitingMiddleware<P> for StateInformationMiddleware {
+impl<K, P: clock::Reference> RateLimitingMiddleware<K, P> for StateInformationMiddleware {
     /// The state snapshot returned from the limiter.
     type PositiveOutcome = StateSnapshot;
 
     type NegativeOutcome = NotUntil<P>;
 
-    fn allow<K>(_key: &K, state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {
+    fn allow(_key: &K, state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {
         state.into()
     }
 
-    fn disallow<K>(
-        _key: &K,
-        state: impl Into<StateSnapshot>,
-        start_time: P,
-    ) -> Self::NegativeOutcome {
+    fn disallow(_key: &K, state: impl Into<StateSnapshot>, start_time: P) -> Self::NegativeOutcome {
         NotUntil::new(state.into(), start_time)
     }
 }
 
 #[cfg(all(feature = "std", test))]
 mod test {
+    #[cfg(all(feature = "std", feature = "dashmap"))]
+    use std::collections::HashMap;
     use std::time::Duration;
 
     use super::*;
@@ -292,5 +257,106 @@ mod test {
             ),
             "NoOpMiddleware"
         );
+    }
+
+    #[test]
+    fn ensure_extant_middleware_gives_no_quota() {
+        assert_eq!(
+            NoOpMiddleware {
+                phantom: PhantomData::<Duration>,
+            }
+            .get_quota(&111),
+            None
+        );
+        let simw = StateInformationMiddleware;
+        assert_eq!(
+            <StateInformationMiddleware as RateLimitingMiddleware<i32, Duration>>::get_quota(
+                &simw, &111
+            ),
+            None
+        );
+        // assert_eq!(simw.get_quota(&111), None);
+    }
+
+    #[cfg(all(feature = "std", feature = "dashmap"))]
+    #[derive(Debug)]
+    pub struct KeyedMw<K: Eq + core::hash::Hash> {
+        // keys: dashmap::DashMap<K, Gcra>,
+        keys: HashMap<K, Gcra>,
+    }
+
+    #[cfg(all(feature = "std", feature = "dashmap"))]
+    impl<K> KeyedMw<K>
+    where
+        K: Eq + core::hash::Hash,
+    {
+        pub fn new<I>(quotas: I) -> Self
+        where
+            I: Iterator<Item = (K, crate::Quota)>,
+        {
+            use std::iter::FromIterator;
+
+            Self {
+                // keys: dashmap::DashMap::from_iter(quotas.map(|(k, q)| (k, Gcra::new(q)))),
+                keys: HashMap::from_iter(quotas.map(|(k, q)| (k, Gcra::new(q)))),
+            }
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "dashmap"))]
+    impl<K, const N: usize> From<[(K, crate::Quota); N]> for KeyedMw<K>
+    where
+        K: Clone + Eq + core::hash::Hash,
+    {
+        fn from(value: [(K, crate::Quota); N]) -> Self {
+            KeyedMw::<K>::new(value.iter().cloned())
+        }
+    }
+
+    #[cfg(all(feature = "std", feature = "dashmap"))]
+    impl<K /*P: clock::Reference*/> RateLimitingMiddleware<K, Duration> for KeyedMw<K>
+    where
+        K: std::fmt::Debug + Eq + core::hash::Hash,
+    {
+        type PositiveOutcome = ();
+
+        type NegativeOutcome = NotUntil<Duration>;
+
+        fn allow(_key: &K, _state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {
+            {}
+        }
+
+        fn disallow(
+            _key: &K,
+            state: impl Into<StateSnapshot>,
+            start_time: Duration,
+        ) -> Self::NegativeOutcome {
+            NotUntil::new(state.into(), start_time)
+        }
+
+        fn get_quota(&self, key: &K) -> Option<&Gcra> {
+            // self.keys.get(key).as_deref()
+            self.keys.get(key)
+        }
+    }
+
+    #[test]
+    #[cfg(all(feature = "std", feature = "dashmap"))]
+    fn trivial_keyed_middleware() {
+        use std::time::Duration;
+
+        use nonzero_ext::nonzero;
+
+        use crate::Quota;
+
+        let quota_1 = Quota {
+            max_burst: nonzero!(3u32),
+            replenish_1_per: Duration::from_millis(250),
+        };
+
+        let mw: KeyedMw<u32> = [(1, quota_1)].into();
+
+        assert!(mw.get_quota(&1).is_some());
+        assert!(mw.get_quota(&2).is_none());
     }
 }

--- a/governor/src/quota.rs
+++ b/governor/src/quota.rs
@@ -59,8 +59,8 @@ use crate::nanos::Nanos;
 /// ```
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Quota {
-    pub(crate) max_burst: NonZeroU32,
-    pub(crate) replenish_1_per: Duration,
+    pub max_burst: NonZeroU32,
+    pub replenish_1_per: Duration,
 }
 
 /// Constructors for Quotas

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -157,5 +157,8 @@ mod test {
     fn ratelimiter_impl_coverage() {
         let lim = RateLimiter::direct(Quota::per_second(nonzero!(3u32)));
         assert_gt!(format!("{lim:?}").len(), 0);
+
+        let lim = lim.use_middleware(NoOpMiddleware::default());
+        assert_gt!(format!("{lim:?}").len(), 0);
     }
 }

--- a/governor/src/state.rs
+++ b/governor/src/state.rs
@@ -1,7 +1,5 @@
 //! State stores for rate limiters
 
-use core::marker::PhantomData;
-
 pub mod direct;
 mod in_memory;
 pub mod keyed;
@@ -58,26 +56,26 @@ pub struct RateLimiter<K, S, C, MW = NoOpMiddleware>
 where
     S: StateStore<Key = K>,
     C: clock::Clock,
-    MW: RateLimitingMiddleware<C::Instant>,
+    MW: RateLimitingMiddleware<K, C::Instant>,
 {
     state: S,
     gcra: Gcra,
     clock: C,
     start: C::Instant,
-    middleware: PhantomData<MW>,
+    middleware: MW,
 }
 
 impl<K, S, C, MW> RateLimiter<K, S, C, MW>
 where
     S: StateStore<Key = K>,
     C: clock::Clock,
-    MW: RateLimitingMiddleware<C::Instant>,
+    MW: RateLimitingMiddleware<K, C::Instant>,
 {
     /// Creates a new rate limiter from components.
     ///
     /// This is the most generic way to construct a rate-limiter; most users should prefer
     /// [`direct`] or other methods instead.
-    pub fn new(quota: Quota, state: S, clock: C) -> Self {
+    pub fn new(quota: Quota, state: S, clock: C, middleware: MW) -> Self {
         let gcra = Gcra::new(quota);
         let start = clock.now();
         RateLimiter {
@@ -85,7 +83,7 @@ where
             clock,
             gcra,
             start,
-            middleware: PhantomData,
+            middleware,
         }
     }
 
@@ -106,14 +104,28 @@ impl<K, S, C, MW> RateLimiter<K, S, C, MW>
 where
     S: StateStore<Key = K>,
     C: clock::Clock,
-    MW: RateLimitingMiddleware<C::Instant>,
+    MW: RateLimitingMiddleware<K, C::Instant>,
 {
     /// Convert the given rate limiter into one that uses a different middleware.
-    pub fn with_middleware<Outer: RateLimitingMiddleware<C::Instant>>(
-        self,
-    ) -> RateLimiter<K, S, C, Outer> {
+    pub fn with_middleware<Outer>(self) -> RateLimiter<K, S, C, Outer>
+    where
+        Outer: RateLimitingMiddleware<K, C::Instant> + Default,
+    {
         RateLimiter {
-            middleware: PhantomData,
+            middleware: <Outer as Default>::default(),
+            state: self.state,
+            gcra: self.gcra,
+            clock: self.clock,
+            start: self.start,
+        }
+    }
+
+    pub fn use_middleware<MW2: RateLimitingMiddleware<K, C::Instant>>(
+        self,
+        mw: MW2,
+    ) -> RateLimiter<K, S, C, MW2> {
+        RateLimiter {
+            middleware: mw,
             state: self.state,
             gcra: self.gcra,
             clock: self.clock,
@@ -127,7 +139,7 @@ impl<K, S, C, MW> RateLimiter<K, S, C, MW>
 where
     S: StateStore<Key = K>,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware<C::Instant>,
+    MW: RateLimitingMiddleware<K, C::Instant>,
 {
     pub(crate) fn reference_reading(&self) -> C::Instant {
         self.clock.reference_point()

--- a/governor/src/state/direct.rs
+++ b/governor/src/state/direct.rs
@@ -55,7 +55,7 @@ where
     /// Constructs a new direct rate limiter for a quota with a custom clock.
     pub fn direct_with_clock(quota: Quota, clock: C) -> Self {
         let state: InMemoryState = Default::default();
-        RateLimiter::new(quota, state, clock)
+        RateLimiter::new(quota, state, clock, NoOpMiddleware::<C::Instant>::default())
     }
 }
 
@@ -64,7 +64,7 @@ impl<S, C, MW> RateLimiter<NotKeyed, S, C, MW>
 where
     S: DirectStateStore,
     C: clock::Clock,
-    MW: RateLimitingMiddleware<C::Instant>,
+    MW: RateLimitingMiddleware<NotKeyed, C::Instant>,
 {
     /// Allow a single cell through the rate limiter.
     ///

--- a/governor/src/state/direct/future.rs
+++ b/governor/src/state/direct/future.rs
@@ -16,7 +16,7 @@ impl<S, C, MW> RateLimiter<NotKeyed, S, C, MW>
 where
     S: DirectStateStore,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+    MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/governor/src/state/direct/sinks.rs
+++ b/governor/src/state/direct/sinks.rs
@@ -21,7 +21,7 @@ where
     fn ratelimit_sink<
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
     >(
         self,
         limiter: &'_ RateLimiter<NotKeyed, D, C, MW>,
@@ -35,7 +35,7 @@ where
     fn ratelimit_sink_with_jitter<
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
     >(
         self,
         limiter: &'_ RateLimiter<NotKeyed, D, C, MW>,
@@ -49,7 +49,7 @@ impl<Item, S: Sink<Item>> SinkRateLimitExt<Item, S> for S {
     fn ratelimit_sink<
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
     >(
         self,
         limiter: &RateLimiter<NotKeyed, D, C, MW>,
@@ -64,7 +64,7 @@ impl<Item, S: Sink<Item>> SinkRateLimitExt<Item, S> for S {
     fn ratelimit_sink_with_jitter<
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
     >(
         self,
         limiter: &RateLimiter<NotKeyed, D, C, MW>,
@@ -92,7 +92,7 @@ pub struct RatelimitedSink<
     S: Sink<Item>,
     D: DirectStateStore,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+    MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
 > {
     inner: S,
     state: State,
@@ -109,7 +109,7 @@ impl<
         S: Sink<Item>,
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
     > RatelimitedSink<'a, Item, S, D, C, MW>
 {
     fn new(inner: S, limiter: &'a RateLimiter<NotKeyed, D, C, MW>, jitter: Jitter) -> Self {
@@ -156,7 +156,7 @@ impl<
         S: Sink<Item>,
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
     > Sink<Item> for RatelimitedSink<'_, Item, S, D, C, MW>
 where
     S: Unpin,
@@ -233,7 +233,7 @@ impl<
         S: Stream + Sink<Item>,
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
     > Stream for RatelimitedSink<'_, Item, S, D, C, MW>
 where
     S::Item: Unpin,

--- a/governor/src/state/direct/streams.rs
+++ b/governor/src/state/direct/streams.rs
@@ -23,7 +23,7 @@ pub trait StreamRateLimitExt<'a>: Stream {
     fn ratelimit_stream<
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant>,
     >(
         self,
         limiter: &'a RateLimiter<NotKeyed, D, C, MW>,
@@ -41,7 +41,7 @@ pub trait StreamRateLimitExt<'a>: Stream {
     fn ratelimit_stream_with_jitter<
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant>,
     >(
         self,
         limiter: &'a RateLimiter<NotKeyed, D, C, MW>,
@@ -55,7 +55,7 @@ impl<'a, S: Stream> StreamRateLimitExt<'a> for S {
     fn ratelimit_stream<
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant>,
     >(
         self,
         limiter: &'a RateLimiter<NotKeyed, D, C, MW>,
@@ -69,7 +69,7 @@ impl<'a, S: Stream> StreamRateLimitExt<'a> for S {
     fn ratelimit_stream_with_jitter<
         D: DirectStateStore,
         C: clock::ReasonablyRealtime,
-        MW: RateLimitingMiddleware<C::Instant>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant>,
     >(
         self,
         limiter: &'a RateLimiter<NotKeyed, D, C, MW>,
@@ -104,7 +104,7 @@ pub struct RatelimitedStream<
     S: Stream,
     D: DirectStateStore,
     C: clock::Clock,
-    MW: RateLimitingMiddleware<C::Instant>,
+    MW: RateLimitingMiddleware<NotKeyed, C::Instant>,
 > {
     inner: S,
     limiter: &'a RateLimiter<NotKeyed, D, C, MW>,
@@ -115,8 +115,12 @@ pub struct RatelimitedStream<
 }
 
 /// Conversion methods for the stream combinator.
-impl<S: Stream, D: DirectStateStore, C: clock::Clock, MW: RateLimitingMiddleware<C::Instant>>
-    RatelimitedStream<'_, S, D, C, MW>
+impl<
+        S: Stream,
+        D: DirectStateStore,
+        C: clock::Clock,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant>,
+    > RatelimitedStream<'_, S, D, C, MW>
 {
     /// Acquires a reference to the underlying stream that this combinator is pulling from.
     /// ```rust
@@ -175,7 +179,7 @@ where
     S::Item: Unpin,
     Self: Unpin,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+    MW: RateLimitingMiddleware<NotKeyed, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
 {
     type Item = S::Item;
 
@@ -240,7 +244,7 @@ impl<
         S: Stream + Sink<Item>,
         D: DirectStateStore,
         C: clock::Clock,
-        MW: RateLimitingMiddleware<C::Instant>,
+        MW: RateLimitingMiddleware<NotKeyed, C::Instant>,
     > Sink<Item> for RatelimitedStream<'_, S, D, C, MW>
 where
     S: Unpin,

--- a/governor/src/state/keyed/dashmap.rs
+++ b/governor/src/state/keyed/dashmap.rs
@@ -42,7 +42,7 @@ where
     /// [`DashMap`] with the default hasher.
     pub fn dashmap_with_clock(quota: Quota, clock: C) -> Self {
         let state: DashMapStateStore<K> = DashMap::default();
-        RateLimiter::new(quota, state, clock)
+        RateLimiter::new(quota, state, clock, NoOpMiddleware::default())
     }
 }
 
@@ -57,7 +57,7 @@ where
     /// [`DashMap`].
     pub fn dashmap_with_clock_and_hasher(quota: Quota, clock: C, hasher: S) -> Self {
         let state: DashMapStateStore<K, S> = DashMap::with_hasher(hasher);
-        RateLimiter::new(quota, state, clock)
+        RateLimiter::new(quota, state, clock, NoOpMiddleware::default())
     }
 }
 

--- a/governor/src/state/keyed/future.rs
+++ b/governor/src/state/keyed/future.rs
@@ -12,7 +12,7 @@ where
     K: Hash + Eq + Clone,
     S: KeyedStateStore<K>,
     C: clock::ReasonablyRealtime,
-    MW: RateLimitingMiddleware<C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
+    MW: RateLimitingMiddleware<K, C::Instant, NegativeOutcome = NotUntil<C::Instant>>,
 {
     /// Asynchronously resolves as soon as the rate limiter allows it.
     ///

--- a/governor/src/state/keyed/hashmap.rs
+++ b/governor/src/state/keyed/hashmap.rs
@@ -76,7 +76,7 @@ where
     /// Constructs a new rate limiter with a custom clock, backed by a [`HashMap`] with the default hasher.
     pub fn hashmap_with_clock(quota: Quota, clock: C) -> Self {
         let state: HashMapStateStore<K> = HashMapStateStore::new(HashMap::default());
-        RateLimiter::new(quota, state, clock)
+        RateLimiter::new(quota, state, clock, NoOpMiddleware::default())
     }
 }
 
@@ -90,6 +90,6 @@ where
     /// Constructs a new rate limiter with a custom clock and hasher, backed by a [`HashMap`].
     pub fn hashmap_with_clock_and_hasher(quota: Quota, clock: C, hasher: S) -> Self {
         let state: HashMapStateStore<K, S> = HashMapStateStore::new(HashMap::with_hasher(hasher));
-        RateLimiter::new(quota, state, clock)
+        RateLimiter::new(quota, state, clock, NoOpMiddleware::default())
     }
 }

--- a/governor/tests/middleware.rs
+++ b/governor/tests/middleware.rs
@@ -1,24 +1,26 @@
 use governor::{
     clock::{self, FakeRelativeClock},
-    middleware::{RateLimitingMiddleware, StateInformationMiddleware, StateSnapshot},
+    gcra::StateSnapshot,
+    middleware::{RateLimitingMiddleware, StateInformationMiddleware},
+    state::NotKeyed,
     Quota, RateLimiter,
 };
 use nonzero_ext::nonzero;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct MyMW;
 
-impl RateLimitingMiddleware<<FakeRelativeClock as clock::Clock>::Instant> for MyMW {
+impl RateLimitingMiddleware<NotKeyed, <FakeRelativeClock as clock::Clock>::Instant> for MyMW {
     type PositiveOutcome = u16;
 
-    fn allow<K>(_key: &K, _state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {
+    fn allow(_key: &NotKeyed, _state: impl Into<StateSnapshot>) -> Self::PositiveOutcome {
         666
     }
 
     type NegativeOutcome = ();
 
-    fn disallow<K>(
-        _key: &K,
+    fn disallow(
+        _key: &NotKeyed,
         _limiter: impl Into<StateSnapshot>,
         _start_time: <FakeRelativeClock as clock::Clock>::Instant,
     ) -> Self::NegativeOutcome {


### PR DESCRIPTION
This patch address issue #193 (KeyedRateLimiter with different quota per key)

It adds a method, `get_quota()` to trait `RateLimitingMiddleware`. `get_quota()` returns an `Option<Gcra>`, and the default implementation simply returns `None` (largely along the lines suggested by twitu).

As antifuchs anticipated, this has required some restructuring:

- until now, middleware were simply types (no state)-- now they can have state. I changed `RateLimiter` to no longer have a phantom member for the middleware, but to actually own its `RateLimitingMiddleware` instance
- I was able to preserve the `with_middleware()` signature by implementing `Default` on the stateless middlewares, and added a new method `use_middleware()` that can take stateful middlewares.
- I moved `StateSnapshot` into gcra.rs in order to avoid introducing a cyclic dependency between modules gcra and middleware (`gcra::NotUntil` needs `StateSnapshot` and `RateLimitingMiddleware` now needs `gcra::Gcra`)
- I made `Quota` and `Gcra` public (not just pub(crate)) so that middleware authors that want to support per-key quotas can use them
- I moved the generic type parameter representing the keys off of `RateLimitingMiddleware` methods and on to the trait itself. It's only with the introduction of `get_quota()` that the type becomes important; it really can't be *anything*, but needs to line-up with the key type parameter to `RateLimiter`.

More tests, additional constructors, and field testing are needed, but I want to post this to begin gathering feedback.